### PR TITLE
feat(server): add support to register REST extensions

### DIFF
--- a/azkarra-api/pom.xml
+++ b/azkarra-api/pom.xml
@@ -100,5 +100,11 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/server/AzkarraRestExtension.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/server/AzkarraRestExtension.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.server;
+
+import io.streamthoughts.azkarra.api.config.Conf;
+import io.streamthoughts.azkarra.api.config.Configurable;
+
+import java.io.Closeable;
+
+/**
+ * A pluggable interface to allow registration of new JAX-RS resources like REST endpoints.
+ * The implementations are discovered using the standard Java {@link java.util.ServiceLoader} mechanism.
+ *
+ * Hence, the fully qualified name of the extension classes that implement the {@link AzkarraRestExtension}
+ * interface must be add to a {@code META-INF/services/io.streamthoughts.azkarra.api.server.AzkarraRestExtension} file.
+ */
+public interface AzkarraRestExtension extends Configurable, Closeable {
+
+    /**
+     * Configures this instance with the specified {@link Conf}.
+     * The configuration passed to the method correspond used for configuring the {@link EmbeddedHttpServer}
+     *
+     * @param configuration  the {@link Conf} instance used to configure this instance.
+     */
+    @Override
+    default void configure(final Conf configuration) {
+
+    }
+
+    /**
+     * The {@link AzkarraRestExtension} implementations should use this method to register JAX-RS resources.
+     * @param restContext   the {@link AzkarraRestExtensionContext} instance.
+     */
+    void register(final AzkarraRestExtensionContext restContext);
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/server/AzkarraRestExtensionContext.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/server/AzkarraRestExtensionContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.server;
+
+import io.streamthoughts.azkarra.api.AzkarraContext;
+
+import javax.ws.rs.core.Configurable;
+
+/**
+ * This interfaces provides the capability for {@link AzkarraRestExtension} implementations
+ * to register JAX-RS resources using the provided {@link Configurable} and to get access to
+ * the {@link AzkarraContext} instance.
+ *
+ * @see AzkarraRestExtension
+ */
+public interface AzkarraRestExtensionContext {
+
+    /**
+     * Provides an implementation of {@link javax.ws.rs.core.Configurable} that
+     * must be used to register JAX-RS resources.
+     *
+     * @return the JAX-RS {@link javax.ws.rs.core.Configurable}.
+     */
+    Configurable<? extends Configurable> configurable();
+
+    /**
+     * Provides the {@link AzkarraContext} instance that can be used to retrieve registered components.
+     *
+     * @return  the {@link AzkarraContext} instance.
+     */
+    AzkarraContext context();
+}

--- a/azkarra-server/pom.xml
+++ b/azkarra-server/pom.xml
@@ -31,6 +31,7 @@
         <checkstyle.config.location>${project.parent.basedir}</checkstyle.config.location>
         <rest.assured.version>4.1.2</rest.assured.version>
         <okhttp.version>4.2.0</okhttp.version>
+        <jersey.version>2.30.1</jersey.version>
     </properties>
 
     <artifactId>azkarra-server</artifactId>
@@ -143,6 +144,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
         </dependency>
@@ -164,10 +177,21 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.streamthoughts</groupId>
             <artifactId>azkarra-ui</artifactId>
             <version>0.7.0-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
         </dependency>
 
         <!-- START dependencies for testing -->

--- a/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/ServerConfBuilder.java
+++ b/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/ServerConfBuilder.java
@@ -34,6 +34,7 @@ public class ServerConfBuilder {
     public static final String HTTP_PORT_CONFIG                    = "port";
     public static final String HTTP_LISTENER_LISTER_CONFIG         = "listener";
     public static final String HTTP_ENABLE_UI                      = "enable.ui";
+    public static final String HTTP_REST_EXTENSIONS_ENABLE         = "rest.extensions.enable";
 
     private final Map<String, Object> configs;
 
@@ -297,6 +298,28 @@ public class ServerConfBuilder {
      */
     public ServerConfBuilder disableHeadlessMode() {
         configs.put(SecurityConfig.HTTP_HEADLESS_CONFIG, false);
+        return this;
+    }
+
+    /**
+     * Enables support for rest extensions.
+     * @see io.streamthoughts.azkarra.api.server.AzkarraRestExtension
+     *
+     * @return  {@code this}
+     */
+    public ServerConfBuilder enableRestExtensions() {
+        configs.put(HTTP_REST_EXTENSIONS_ENABLE, true);
+        return this;
+    }
+
+    /**
+     * Disables support for rest extensions.
+     * @see io.streamthoughts.azkarra.api.server.AzkarraRestExtension
+     *
+     * @return  {@code this}
+     */
+    public ServerConfBuilder disableRestExtensions() {
+        configs.put(HTTP_REST_EXTENSIONS_ENABLE, false);
         return this;
     }
 

--- a/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/error/AzkarraExceptionMapper.java
+++ b/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/error/AzkarraExceptionMapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.http.error;
+
+import io.streamthoughts.azkarra.http.data.ErrorMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * The default JAX-RS {@link ExceptionMapper} implementation.
+ */
+public class AzkarraExceptionMapper implements ExceptionMapper<Exception> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AzkarraExceptionMapper.class);
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Override
+    public Response toResponse(final Exception exception) {
+        final ErrorMessage errorMessage = ErrorMessage.of(exception, uriInfo.getPath());
+        final int statusCode = errorMessage.getErrorCode();
+        if (statusCode == 500) {
+            LOG.error("Uncaught server exception in REST call to /{}", uriInfo.getPath(), exception);
+        }
+        return Response.status(statusCode).entity(errorMessage).build();
+    }
+}

--- a/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/handler/HeadlessHttpHandler.java
+++ b/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/handler/HeadlessHttpHandler.java
@@ -31,16 +31,12 @@ import java.util.List;
 
 public class HeadlessHttpHandler implements HttpHandler {
 
-    private boolean headless;
     private final HttpHandler next;
 
     /**
      * Creates a new {@link HeadlessHttpHandler} instance.
-     *
-     * @param enable    is headless mode enable.
      */
-    public HeadlessHttpHandler(final boolean enable, final HttpHandler next) {
-        this.headless = enable;
+    public HeadlessHttpHandler(final HttpHandler next) {
         this.next = next;
     }
 
@@ -51,7 +47,7 @@ public class HeadlessHttpHandler implements HttpHandler {
     public void handleRequest(final HttpServerExchange exchange) throws Exception {
         final HttpString method = exchange.getRequestMethod();
         final String path = exchange.getRelativePath();
-        if (headless && isOperationRestricted(path, method) && isNotQueryStore(path, method)) {
+        if (isOperationRestricted(path, method) && isNotQueryStore(path, method)) {
             ErrorMessage error = new ErrorMessage(
                 StatusCodes.FORBIDDEN,
                 "Server is running in headless mode -" +

--- a/azkarra-server/src/test/java/io/streamthoughts/azkarra/http/UndertowEmbeddedServerIT.java
+++ b/azkarra-server/src/test/java/io/streamthoughts/azkarra/http/UndertowEmbeddedServerIT.java
@@ -60,7 +60,7 @@ public class UndertowEmbeddedServerIT {
             .assertThat()
             .statusCode(500)
             .contentType("application/json")
-            .body("message", response -> equalTo("Internal Azkarra Streams API Error : Testing error"))
+            .body("message", response -> equalTo("Internal Azkarra Streams API Error: Testing error"))
             .body("error_code", response -> equalTo(500));
     }
 }

--- a/azkarra-server/src/test/java/io/streamthoughts/azkarra/http/UndertowEmbeddedWithServletContainerIT.java
+++ b/azkarra-server/src/test/java/io/streamthoughts/azkarra/http/UndertowEmbeddedWithServletContainerIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.http;
+
+import io.restassured.RestAssured;
+import io.streamthoughts.azkarra.api.config.Conf;
+import io.streamthoughts.azkarra.api.server.AzkarraRestExtension;
+import io.streamthoughts.azkarra.api.server.AzkarraRestExtensionContext;
+import io.streamthoughts.azkarra.runtime.context.DefaultAzkarraContext;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class UndertowEmbeddedWithServletContainerIT {
+
+    private static UndertowEmbeddedServer SERVER;
+
+    @BeforeAll
+    public static void setUpAll() {
+        SERVER = new UndertowEmbeddedServer(
+                DefaultAzkarraContext.create(),
+                true
+        );
+        // Enable REST_EXTENSIONS to configure undertow with servlet handler
+        Conf serverConfig = ServerConfBuilder.newBuilder().enableRestExtensions().build();
+        SERVER.configure(serverConfig);
+        SERVER.start();
+    }
+
+    @AfterAll
+    public static void tearDownAll() {
+        SERVER.stop();
+    }
+
+    @Test
+    public void shouldDiscoverAndRegisterRestExtensionUsingJavaServiceLoader() {
+        Collection<AzkarraRestExtension> registered = SERVER.getRegisteredExtensions();
+        Assertions.assertEquals(1, registered.size());
+        Assertions.assertEquals(registered.iterator().next().getClass(), TestAzkarraRestExtension.class);
+
+        RestAssured.when().get("/test")
+            .then()
+            .assertThat()
+            .statusCode(200)
+            .contentType("application/json")
+            .body("key", response -> equalTo("dummy"));
+    }
+
+    @Path("/")
+    @Produces(MediaType.APPLICATION_JSON)
+    public static class TestResource {
+        @GET
+        @Path("/test")
+        public Object get() {
+            return Map.of("key", "dummy");
+        }
+    }
+
+    public static class TestAzkarraRestExtension implements AzkarraRestExtension {
+
+        @Override
+        public void register(final AzkarraRestExtensionContext restContext) {
+            restContext.configurable().register(TestResource.class);
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+    }
+}

--- a/azkarra-server/src/test/java/io/streamthoughts/azkarra/http/handler/HeadlessHttpHandlerTest.java
+++ b/azkarra-server/src/test/java/io/streamthoughts/azkarra/http/handler/HeadlessHttpHandlerTest.java
@@ -36,46 +36,35 @@ public class HeadlessHttpHandlerTest {
 
     @Test
     public void shouldAllowAccessForPostRequestWhenHeadlessEnable() throws Exception {
-        assertRequestStatusCode(true, Methods.POST, "/info", StatusCodes.OK);
+        assertRequestStatusCode(Methods.POST, "/info", StatusCodes.OK);
     }
 
     @Test
     public void shouldAllowAccessForApiPostStoresRequestWhenHeadlessEnable() throws Exception {
-        assertRequestStatusCode(true, Methods.POST, "/api/applications/42/stores/", StatusCodes.OK);
+        assertRequestStatusCode(Methods.POST, "/api/applications/42/stores/", StatusCodes.OK);
     }
 
     @Test
     public void shouldAllowAccessForApiGetRequestWhenHeadlessEnable() throws Exception {
-        assertRequestStatusCode(true, Methods.GET, API_BASE_PATH, StatusCodes.OK);
+        assertRequestStatusCode(Methods.GET, API_BASE_PATH, StatusCodes.OK);
     }
 
     @Test
     public void shouldDenyAccessForApiPostRequestWhenHeadlessEnable() throws Exception {
-        assertRequestStatusCode(true, Methods.POST, API_BASE_PATH, StatusCodes.FORBIDDEN);
+        assertRequestStatusCode(Methods.POST, API_BASE_PATH, StatusCodes.FORBIDDEN);
     }
 
     @Test
     public void shouldDenyAccessForApiDeleteRequestWhenHeadlessEnable() throws Exception {
-        assertRequestStatusCode(true, Methods.DELETE, API_BASE_PATH, StatusCodes.FORBIDDEN);
+        assertRequestStatusCode(Methods.DELETE, API_BASE_PATH, StatusCodes.FORBIDDEN);
     }
 
-    @Test
-    public void shouldAllowAccessForApiDeleteRequestWhenHeadlessDisable() throws Exception {
-        assertRequestStatusCode(false, Methods.DELETE, API_BASE_PATH, StatusCodes.OK);
-    }
-
-    @Test
-    public void shouldAllowAccessForApiPostRequestWhenHeadlessDisable() throws Exception {
-        assertRequestStatusCode(false, Methods.POST, API_BASE_PATH, StatusCodes.OK);
-    }
-
-    private void assertRequestStatusCode(final boolean headless,
-                                         final HttpString method,
+    private void assertRequestStatusCode(final HttpString method,
                                          final String relativePath,
                                          final int statusCode) throws Exception {
 
         final HttpHandler mkHandler = mock(HttpHandler.class);
-        final HeadlessHttpHandler handler = new HeadlessHttpHandler(headless, mkHandler);
+        final HeadlessHttpHandler handler = new HeadlessHttpHandler(mkHandler);
 
         final HttpServerExchange exchange = new HttpServerExchange(
             mock(ServerConnection.class),

--- a/azkarra-server/src/test/resources/META-INF/services/io.streamthoughts.azkarra.api.server.AzkarraRestExtension
+++ b/azkarra-server/src/test/resources/META-INF/services/io.streamthoughts.azkarra.api.server.AzkarraRestExtension
@@ -1,0 +1,1 @@
+io.streamthoughts.azkarra.http.UndertowEmbeddedWithServletContainerIT$TestAzkarraRestExtension

--- a/azkarra-server/src/test/resources/logback-test.xml
+++ b/azkarra-server/src/test/resources/logback-test.xml
@@ -1,0 +1,35 @@
+<!--
+ Copyright 2019 StreamThoughts.
+
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements. See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<configuration debug="false">
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.streamthoughts.azkarra" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/azkarra-streams/src/main/java/io/streamthoughts/azkarra/streams/AzkarraApplication.java
+++ b/azkarra-streams/src/main/java/io/streamthoughts/azkarra/streams/AzkarraApplication.java
@@ -419,7 +419,6 @@ public class AzkarraApplication {
             final String server = info.getHost() + ":" + info.getPort();
             final Conf serverConfig = Conf.with(StreamsConfig.APPLICATION_SERVER_CONFIG, server);
             context.addConfiguration(Conf.with("streams", serverConfig));
-            LOG.info("Embedded server start listening on {}", info);
         }
 
         /**


### PR DESCRIPTION
This commits provides ability for users to plug custom JAX-RS resources
that will be initialized and served by Undertow embedded server.

This feature uses the standard Java ServiceLoader mechanism to discover
the classes to load.

- add new API classes AzkarraRestExtension and AzkarraRestExtensionContext
- add new server property rest.extensions.enable to disable/enable this feature (by default false)
- refactor UndertowEmbeddedServer

Resolves: #63