### PR TITLE
feat(api): add support for Secondary component qualifier

### DIFF
--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/annotations/Secondary.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/annotations/Secondary.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker interface to indicate that a component must be de-prioritize
+ * in the case of multiple possible implementations.
+ *
+ * @see io.streamthoughts.azkarra.api.components.ComponentRegistry
+ * @see io.streamthoughts.azkarra.api.components.ComponentFactory
+ * @see Component
+ */
+@Documented
+@Inherited
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Secondary {
+
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentDescriptor.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentDescriptor.java
@@ -18,6 +18,7 @@
  */
 package io.streamthoughts.azkarra.api.components;
 
+import io.streamthoughts.azkarra.api.components.qualifier.Qualifiers;
 import io.streamthoughts.azkarra.api.util.Version;
 
 import java.io.Closeable;
@@ -129,7 +130,17 @@ public interface ComponentDescriptor<T> extends Ordered {
      * Checks if the described component is the primary component
      * that must be selected in the case of multiple possible implementations.
      *
+     * @see Qualifiers#byPrimary()
+     *
      * @return {@code true } if is primary, otherwise {@code false}.
      */
     boolean isPrimary();
+
+    /**
+     * Checks if the described component is a secondary component that
+     * must be  de-prioritize in the case of multiple possible implementations.
+     *
+     * @return {@code true } if is secondary, otherwise {@code false}.
+     */
+    boolean isSecondary();
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/SimpleComponentDescriptor.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/SimpleComponentDescriptor.java
@@ -50,6 +50,8 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
 
     private final boolean isPrimary;
 
+    private final boolean isSecondary;
+
     private final int order;
 
     /**
@@ -64,7 +66,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
                                      final Class<T> type,
                                      final Supplier<T> supplier,
                                      final boolean isSingleton) {
-        this(name, type, type.getClassLoader(), supplier, null, isSingleton, false, Ordered.LOWEST_ORDER);
+        this(name, type, type.getClassLoader(), supplier, null, isSingleton, false, false, Ordered.LOWEST_ORDER);
     }
 
     /**
@@ -81,7 +83,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
                                      final Supplier<T> supplier,
                                      final String version,
                                      final boolean isSingleton) {
-        this(name, type, type.getClassLoader(), supplier, version, isSingleton, false, Ordered.LOWEST_ORDER);
+        this(name, type, type.getClassLoader(), supplier, version, isSingleton, false, false, Ordered.LOWEST_ORDER);
     }
 
     /**
@@ -101,6 +103,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
                                      final String version,
                                      final boolean isSingleton,
                                      final boolean isPrimary,
+                                     final boolean isSecondary,
                                      final int order) {
         Objects.requireNonNull(type, "type can't be null");
         Objects.requireNonNull(supplier, "supplier can't be null");
@@ -113,6 +116,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
         this.metadata = new ComponentMetadata();
         this.isSingleton = isSingleton;
         this.isPrimary = isPrimary;
+        this.isSecondary = isSecondary;
         this.order = order;
     }
 
@@ -130,6 +134,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
             descriptor.version().toString(),
             descriptor.isSingleton(),
             descriptor.isPrimary(),
+            descriptor.isSecondary(),
             descriptor.order()
         );
         metadata = descriptor.metadata();
@@ -226,6 +231,14 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
     @Override
     public boolean isPrimary() {
         return isPrimary;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isSecondary() {
+        return isSecondary;
     }
 
     /**

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/qualifier/Qualifiers.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/qualifier/Qualifiers.java
@@ -32,6 +32,14 @@ public class Qualifiers {
         return new PrimaryQualifier<>();
     }
 
+    public static <T> Qualifier<T> bySecondary() {
+        return new SecondaryQualifier<>(false);
+    }
+
+    public static <T> Qualifier<T> excludeSecondary() {
+        return new SecondaryQualifier<>(true);
+    }
+
     public static <T> Qualifier<T> byName(final String name) {
         return new NamedQualifier<>(name);
     }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/qualifier/SecondaryQualifier.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/qualifier/SecondaryQualifier.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.components.qualifier;
+
+import io.streamthoughts.azkarra.api.components.ComponentDescriptor;
+import io.streamthoughts.azkarra.api.components.Qualifier;
+
+import java.util.stream.Stream;
+
+public class SecondaryQualifier<T> implements Qualifier<T> {
+
+    private final boolean exclude;
+
+    /**
+     * Creates a new {@link SecondaryQualifier} instance.
+     *
+     * @param exclude exclude secondary if equals to {@code true}.
+     */
+    public SecondaryQualifier(final boolean exclude) {
+        this.exclude = exclude;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<ComponentDescriptor<T>> filter(final Class<T> componentType,
+                                                 final Stream<ComponentDescriptor<T>> candidates) {
+        return candidates.filter(desc -> exclude ^ desc.isSecondary());
+    }
+}

--- a/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/components/ComponentDescriptorTest.java
+++ b/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/components/ComponentDescriptorTest.java
@@ -89,6 +89,7 @@ public class ComponentDescriptorTest {
                 null,
                 true,
                 false,
+                false,
                 order
         );
     }
@@ -101,6 +102,7 @@ public class ComponentDescriptorTest {
             () -> null,
             version,
             true,
+            false,
             false,
             Ordered.LOWEST_ORDER
         );

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorBuilder.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorBuilder.java
@@ -38,6 +38,7 @@ public class ComponentDescriptorBuilder<T> implements ComponentDescriptor<T> {
     private Supplier<T> supplier;
     private boolean isSingleton;
     private boolean isPrimary;
+    private boolean isSecondary;
     private Set<String> aliases = new HashSet<>();
     private int order;
 
@@ -219,12 +220,22 @@ public class ComponentDescriptorBuilder<T> implements ComponentDescriptor<T> {
         return this;
     }
 
+    public ComponentDescriptorBuilder<T> isSecondary(final boolean isSecondary) {
+        this.isSecondary = isSecondary;
+        return this;
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     public boolean isPrimary() {
         return isPrimary;
+    }
+
+    @Override
+    public boolean isSecondary() {
+        return false;
     }
 
     /**
@@ -255,6 +266,7 @@ public class ComponentDescriptorBuilder<T> implements ComponentDescriptor<T> {
             version,
             isSingleton,
             isPrimary,
+            isSecondary,
             order
         );
         descriptor.metadata(metadata);

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorModifiers.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorModifiers.java
@@ -23,6 +23,11 @@ import io.streamthoughts.azkarra.api.components.ComponentDescriptorModifier;
 
 public class ComponentDescriptorModifiers {
 
+    /**
+     * Gets a modifier implementation that will set a component as primary.
+     *
+     * @return  a new {@link ComponentDescriptorModifier} instance.
+     */
     public static ComponentDescriptorModifier asPrimary() {
         return new ComponentDescriptorModifier() {
             @Override
@@ -34,6 +39,28 @@ public class ComponentDescriptorModifiers {
         };
     }
 
+    /**
+     * Gets a modifier implementation that will set a component as secondary.
+     *
+     * @return  a new {@link ComponentDescriptorModifier} instance.
+     */
+    public static ComponentDescriptorModifier asSecondary() {
+        return new ComponentDescriptorModifier() {
+            @Override
+            public <T> ComponentDescriptor<T> apply(final ComponentDescriptor<T> descriptor) {
+                return ComponentDescriptorBuilder.<T>create(descriptor)
+                    .isSecondary(true)
+                    .build();
+            }
+        };
+    }
+
+    /**
+     * Gets a modifier implementation that will set the given order of the component.
+     *
+     * @param order the component order to set.
+     * @return      a new {@link ComponentDescriptorModifier} instance.
+     */
     public static ComponentDescriptorModifier withOrder(final int order) {
         return new ComponentDescriptorModifier() {
             @Override

--- a/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/components/DefaultComponentFactoryTest.java
+++ b/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/components/DefaultComponentFactoryTest.java
@@ -86,6 +86,16 @@ public class DefaultComponentFactoryTest {
         Assertions.assertEquals("componentTwo", descriptor.get().name());
     }
 
+    @Test
+    public void shouldNotThrowNoUniqueComponentExceptionGivenTwoSameTypeComponentsUsingSecondary() {
+        factory.registerComponent("componentOne", TestB.class, TestB::new);
+        factory.registerComponent("componentTwo", TestB.class, TestB::new, asSecondary());
+
+        Optional<ComponentDescriptor<TestB>> descriptor = factory.findDescriptorByClass(TestB.class);
+        Assertions.assertTrue(descriptor.isPresent());
+        Assertions.assertEquals("componentOne", descriptor.get().name());
+    }
+
 
     @Test
     public void shouldThrowConflictingComponentExceptionGivenTwoIdenticalComponents() {

--- a/azkarra-streams/src/main/java/io/streamthoughts/azkarra/streams/components/ComponentScanner.java
+++ b/azkarra-streams/src/main/java/io/streamthoughts/azkarra/streams/components/ComponentScanner.java
@@ -22,6 +22,7 @@ import io.streamthoughts.azkarra.api.annotations.Component;
 import io.streamthoughts.azkarra.api.annotations.Factory;
 import io.streamthoughts.azkarra.api.annotations.Order;
 import io.streamthoughts.azkarra.api.annotations.Primary;
+import io.streamthoughts.azkarra.api.annotations.Secondary;
 import io.streamthoughts.azkarra.api.components.ComponentDescriptorModifier;
 import io.streamthoughts.azkarra.api.components.ComponentFactory;
 import io.streamthoughts.azkarra.api.components.ComponentRegistry;
@@ -218,6 +219,7 @@ public class ComponentScanner {
 
         mayAddModifierForOrder(method, modifiers);
         mayAddModifierForPrimary(method, modifiers);
+        mayAddModifierForSecondary(method, modifiers);
 
         final ComponentDescriptorModifier[] objects = modifiers.toArray(new ComponentDescriptorModifier[]{});
         registerComponent(componentName, componentClass, supplier, isSingleton(method), objects);
@@ -241,6 +243,7 @@ public class ComponentScanner {
         List<ComponentDescriptorModifier> modifiers = new ArrayList<>();
         mayAddModifierForOrder(cls, modifiers);
         mayAddModifierForPrimary(cls, modifiers);
+        mayAddModifierForSecondary(cls, modifiers);
         final ComponentDescriptorModifier[] arrayModifiers = modifiers.toArray(new ComponentDescriptorModifier[]{});
 
         final String componentName = getNamedQualifierOrNull(cls);
@@ -315,6 +318,18 @@ public class ComponentScanner {
                                                  final List<ComponentDescriptorModifier> modifiers) {
         if (ClassUtils.isMethodAnnotatedWith(method, Primary.class))
             modifiers.add(ComponentDescriptorModifiers.asPrimary());
+    }
+
+    private static void mayAddModifierForSecondary(final Method method,
+                                                   final List<ComponentDescriptorModifier> modifiers) {
+        if (ClassUtils.isMethodAnnotatedWith(method, Secondary.class))
+            modifiers.add(ComponentDescriptorModifiers.asSecondary());
+    }
+
+    private static void mayAddModifierForSecondary(final Class<?> componentClass,
+                                                   final List<ComponentDescriptorModifier> modifiers) {
+        if (ClassUtils.isSuperTypesAnnotatedWith(componentClass, Secondary.class))
+            modifiers.add(ComponentDescriptorModifiers.asSecondary());
     }
 
     // The Reflections class may throw a ReflectionsException when parallel executor

--- a/azkarra-streams/src/test/java/io/streamthoughts/azkarra/streams/components/ComponentScannerTest.java
+++ b/azkarra-streams/src/test/java/io/streamthoughts/azkarra/streams/components/ComponentScannerTest.java
@@ -20,6 +20,7 @@ package io.streamthoughts.azkarra.streams.components;
 
 import io.streamthoughts.azkarra.api.annotations.Component;
 import io.streamthoughts.azkarra.api.components.ComponentDescriptor;
+import io.streamthoughts.azkarra.api.components.ComponentDescriptorModifier;
 import io.streamthoughts.azkarra.api.components.qualifier.Qualifiers;
 import io.streamthoughts.azkarra.api.streams.TopologyProvider;
 import io.streamthoughts.azkarra.api.util.Version;
@@ -28,6 +29,7 @@ import io.streamthoughts.azkarra.runtime.components.DefaultComponentFactory;
 import io.streamthoughts.azkarra.streams.MockTopologyProvider;
 import io.streamthoughts.azkarra.streams.components.scan.component.TestAnnotatedComponent;
 import io.streamthoughts.azkarra.streams.components.scan.factory.TestAnnotatedFactory;
+import io.streamthoughts.azkarra.streams.components.scan.secondary.TestSecondaryComponent;
 import io.streamthoughts.azkarra.streams.components.scan.supplier.TestSupplier;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.description.annotation.AnnotationDescription;
@@ -129,6 +131,17 @@ public class ComponentScannerTest {
             Mockito.eq("namedComponent"),
             Mockito.argThat(new ClassMatcher(TestAnnotatedFactory.DummyComponent.class)),
             Mockito.any(Supplier.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldScanAndRegisterDeclaredSecondaryComponent() {
+        scanner.scanForPackage(TestSecondaryComponent.class.getPackage());
+        Mockito.verify(factory).registerComponent(
+            Matchers.isNull(String.class),
+            Mockito.argThat(new ClassMatcher(TestSecondaryComponent.class)),
+            Mockito.any(Supplier.class),
+            Mockito.any(ComponentDescriptorModifier.class));
     }
 
     @Test

--- a/azkarra-streams/src/test/java/io/streamthoughts/azkarra/streams/components/scan/secondary/TestSecondaryComponent.java
+++ b/azkarra-streams/src/test/java/io/streamthoughts/azkarra/streams/components/scan/secondary/TestSecondaryComponent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019-2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.streams.components.scan.secondary;
+
+import io.streamthoughts.azkarra.api.annotations.Component;
+import io.streamthoughts.azkarra.api.annotations.Factory;
+import io.streamthoughts.azkarra.api.annotations.Secondary;
+import io.streamthoughts.azkarra.streams.components.ComponentScannerTest;
+
+/**
+ * Class used for testing purpose.
+ * @see ComponentScannerTest
+ */
+@Component
+@Secondary
+public class TestSecondaryComponent {
+
+}


### PR DESCRIPTION
This commit adds the capability to de-prioritize a registered component
in the case of multiple possible implementations using a new Secondary annotation.

  - add new annotation class Secondary
  - add new SecondaryQualifier class