### PR TITLE
feat(api): add support for conditional component.

### DIFF
--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/AzkarraContext.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/AzkarraContext.java
@@ -37,18 +37,11 @@ import java.util.Set;
 public interface AzkarraContext extends ConfigurableComponentFactory, ComponentRegistry {
 
     /**
-     * Sets the internal the {@link ComponentFactory} which is used for registering components to this context.
-     *
-     * @param factory  the {@link ComponentFactory} instance to be used.
-     * @return         this {@link AzkarraContext} instance.
-     */
-    AzkarraContext setComponentFactory(final ComponentFactory factory);
-
-    /**
      * Gets the internal {@link ComponentFactory}.
      *
      * @return  the {@link ComponentFactory} instance to be used.
      */
+    @Override
     ComponentFactory getComponentFactory();
 
     /**
@@ -74,6 +67,7 @@ public interface AzkarraContext extends ConfigurableComponentFactory, ComponentR
      *
      * @return a {@link Conf} instance.
      */
+    @Override
     Conf getConfiguration();
 
     /**
@@ -170,12 +164,19 @@ public interface AzkarraContext extends ConfigurableComponentFactory, ComponentR
                               final Executed executed);
 
     /**
-     * Gets all topologies registered into this {@link AzkarraContext}.
-     * Note, if provider scan is enable then topologies will be scan when this {@link AzkarraContext} will be started.
+     * Gets all topologies registered into this {@link AzkarraContext} even those ones which are not enable.
      *
      * @return a set of {@link TopologyDescriptor}.
      */
     Set<TopologyDescriptor> topologyProviders();
+
+    /**
+     * Gets all topologies registered into this {@link AzkarraContext} which are available for the given environment.
+     *
+     * @param env the {@link StreamsExecutionEnvironment}
+     * @return    a set of {@link TopologyDescriptor}.
+     */
+    Set<TopologyDescriptor> topologyProviders(final StreamsExecutionEnvironment env);
 
     /**
      * Gets all {@link StreamsExecutionEnvironment} registered to this context.

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/StreamsLifecycleContext.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/StreamsLifecycleContext.java
@@ -19,8 +19,12 @@
 package io.streamthoughts.azkarra.api;
 
 import io.streamthoughts.azkarra.api.config.Conf;
+import io.streamthoughts.azkarra.api.streams.KafkaStreamsContainer;
 import io.streamthoughts.azkarra.api.streams.State;
+import io.streamthoughts.azkarra.api.util.Version;
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.TopologyDescription;
+
 
 /**
  * Context about the current {@link org.apache.kafka.streams.KafkaStreams} instance.
@@ -28,32 +32,42 @@ import org.apache.kafka.streams.TopologyDescription;
 public interface StreamsLifecycleContext {
 
     /**
-     * Gets the application identifier of the current streams instance.
+     * Gets {@code application.id} of the current streams instance.
      *
-     * @return  the application id.
+     * @return  return {@code application.id} of the current streams instance.
      */
-    String getApplicationId();
+    String applicationId();
 
     /**
-     * Gets the topology description of the current streams instance.
+     * Gets the {@link TopologyDescription} of the current streams instance.
      *
-     * @return  the {@link TopologyDescription} instance.
+     * @return  the {@link TopologyDescription} instance; cannot be {@code null}.
      */
-    TopologyDescription getTopology();
+    TopologyDescription topologyDescription();
+
+    /**
+     * @return  the user-specified name for the streams.
+     */
+    String topologyName();
+
+    /**
+     * @return  the version of the streams topology.
+     */
+    Version topologyVersion();
 
     /**
      * Gets the configuration of the current streams instance.
      *
-     * @return  the {@link Conf} instance.
+     * @return  the {@link Conf} instance; cannot be {@code null}.
      */
-    Conf getStreamConfig();
+    Conf streamsConfig();
 
     /**
-     * Gets the state of the current streams instance.
+     * Gets the state value of the current streams instance.
      *
-     * @return  the {@link State}.
+     * @return  the {@link State}; cannot be {@code null}.
      */
-    State getState();
+    State streamsState();
 
     /**
      * Sets the state of the current streams instance.
@@ -61,4 +75,12 @@ public interface StreamsLifecycleContext {
      * @param state the new {@link State}.
      */
     void setState(final State state);
+
+    /**
+     * Register a watcher to be notified of {@link KafkaStreams.State} change event.
+     *
+     * @param watcher   the {@link KafkaStreamsContainer.StateChangeWatcher} to be registered.
+     */
+    void addStateChangeWatcher(final KafkaStreamsContainer.StateChangeWatcher watcher);
+
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/annotations/ConditionalOn.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/annotations/ConditionalOn.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.azkarra.api.annotations;
+
+import io.streamthoughts.azkarra.api.components.condition.Condition;
+import io.streamthoughts.azkarra.api.components.condition.TrueCondition;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be used to indicate the condition(s) that need to be fulfilled for a component to be eligible
+ * for use in the application.
+ */
+@Documented
+@Inherited
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(Conditionals.class)
+public @interface ConditionalOn {
+    /**
+     * Specify the name of the property that should be set.
+     */
+    String property() default "";
+
+    /**
+     * Specify the name of the property that should be missing.
+     */
+    String missingProperty() default "";
+
+    /**
+     * Specify the expected value for the {@link #property()}.
+     */
+    String havingValue() default "";
+
+    /**
+     * Specify the value that the {@link #property()} should not be equals to.
+     */
+    String notEquals() default "";
+
+    /**
+     * Specify the pattern that the {@link #property()} should match.
+     */
+    String matching() default "";
+
+    /**
+     * Specify that components of the given types must be registered for the component to be enabled.
+     */
+    Class[] components() default {};
+
+    /**
+     * Specify that components of the given types must be missing for the component to be enabled.
+     */
+    Class[] missingComponents() default {};
+
+    /**
+     * Specify one or more conditions that the component must match.
+     */
+    Class<? extends Condition>[] conditions() default TrueCondition.class;
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/annotations/Conditionals.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/annotations/Conditionals.java
@@ -16,24 +16,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.components;
+
+package io.streamthoughts.azkarra.api.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * @see io.streamthoughts.azkarra.api.annotations.Order
+ * This annotation can be used to indicate all the conditions that need to be fulfilled for a component to be eligible
+ * for use in the application.
  */
-public interface Ordered extends Comparable<Ordered> {
-
-    int HIGHEST_ORDER = Integer.MIN_VALUE;
-
-    int LOWEST_ORDER = Integer.MAX_VALUE;
-
-    int order();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    default int compareTo(final Ordered that) {
-        return Integer.compare(this.order(), that.order());
-    }
+@Documented
+@Inherited
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Conditionals {
+    ConditionalOn[] value();
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentDescriptor.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentDescriptor.java
@@ -18,11 +18,13 @@
  */
 package io.streamthoughts.azkarra.api.components;
 
+import io.streamthoughts.azkarra.api.components.condition.Condition;
 import io.streamthoughts.azkarra.api.components.qualifier.Qualifiers;
 import io.streamthoughts.azkarra.api.util.Version;
 
 import java.io.Closeable;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -132,15 +134,26 @@ public interface ComponentDescriptor<T> extends Ordered {
      *
      * @see Qualifiers#byPrimary()
      *
-     * @return {@code true } if is primary, otherwise {@code false}.
+     * @return {@code true} if is primary, otherwise {@code false}.
      */
     boolean isPrimary();
 
     /**
      * Checks if the described component is a secondary component that
-     * must be  de-prioritize in the case of multiple possible implementations.
+     * must be de-prioritize in the case of multiple possible implementations.
      *
-     * @return {@code true } if is secondary, otherwise {@code false}.
+     * @see Qualifiers#bySecondary()
+     * @see Qualifiers#excludeSecondary()
+     *
+     * @return {@code true} if is secondary, otherwise {@code false}.
      */
     boolean isSecondary();
+
+    /**
+     * Gets the {@link Condition}  that need to be fulfilled for
+     * this component to be eligible for use in the application.
+     *
+     * @return  the {@link Condition}s.
+     */
+    Optional<Condition> condition();
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentFactory.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentFactory.java
@@ -18,6 +18,7 @@
  */
 package io.streamthoughts.azkarra.api.components;
 
+import io.streamthoughts.azkarra.api.components.condition.Condition;
 import io.streamthoughts.azkarra.api.config.Conf;
 import io.streamthoughts.azkarra.api.config.Configurable;
 
@@ -25,18 +26,20 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 
-public interface ComponentFactory extends ComponentRegistry, ComponentDescriptorRegistry, Closeable {
+public interface ComponentFactory extends
+        ComponentRegistry, ComponentDescriptorRegistry, ConditionalDescriptorRegistry, Closeable {
 
     /**
-     * Checks whether the specified components class or alias is already registered.
+     * Checks if at least one component is registered for the given type.
      *
      * @param type   the fully qualified class name or an alias of the component.
+     *
      * @return       {@code true} if a provider exist, {@code false} otherwise.
      */
     boolean containsComponent(final String type);
 
     /**
-     * Checks whether a components is already registered for the specified type and scope.
+     * Checks if at least one component is registered for the given type and qualifier.
      *
      * @param type       the component type.
      * @param qualifier  the options to qualified the component.
@@ -45,7 +48,7 @@ public interface ComponentFactory extends ComponentRegistry, ComponentDescriptor
     <T> boolean containsComponent(final String type, final Qualifier<T> qualifier);
 
     /**
-     * Checks whether a components is already registered for the specified class.
+     * Checks if at least one component is registered for the given type.
      *
      * @param type  the component type.
      * @return      {@code true} if a provider exist, {@code false} otherwise.
@@ -53,7 +56,7 @@ public interface ComponentFactory extends ComponentRegistry, ComponentDescriptor
     <T> boolean containsComponent(final Class<T> type) ;
 
     /**
-     * Checks whether a components is already registered for the specified type and scope.
+     * Checks if at least one component is registered for the given type and qualifier.
      *
      * @param type       the component type.
      * @param qualifier  the options to qualified the component.
@@ -102,10 +105,15 @@ public interface ComponentFactory extends ComponentRegistry, ComponentDescriptor
      * @throws NoUniqueComponentException   if more than one component is registered for the given type.
      * @throws NoSuchComponentException     if no component is registered for the given type.
      */
-    <T> GettableComponent<T> getComponent(final Class<T> type, final Qualifier<T> qualifier);
+    <T> GettableComponent<T> getComponentProvider(final Class<T> type,
+                                                  final Qualifier<T> qualifier);
 
     /**
      * Gets an instance, which may be shared or independent, for the specified type.
+     *
+     * If the object, returned from that method, implements the {@link Configurable} interface, then the
+     * factory will invoke the method {@link Configurable#configure(Conf)} with the given {@link Conf}.
+     * For a shared object, the method will be invoked only the first time it is returned.
      *
      * @param type   the fully qualified class name or an alias of the component.
      * @param conf   the configuration used if the component implement {@link Configurable}.
@@ -120,6 +128,10 @@ public interface ComponentFactory extends ComponentRegistry, ComponentDescriptor
 
     /**
      * Gets an instance, which may be shared or independent, for the specified type.
+     *
+     * If the object, returned from that method, implements the {@link Configurable} interface, then the
+     * factory will invoke the method {@link Configurable#configure(Conf)} with the given {@link Conf}.
+     * For a shared object, the method will be invoked only the first time it is returned.
      *
      * @param type       the fully qualified class name or an alias of the component.
      * @param conf       the configuration used if the component implement {@link Configurable}.
@@ -136,16 +148,24 @@ public interface ComponentFactory extends ComponentRegistry, ComponentDescriptor
     /**
      * Gets all instances, which may be shared or independent, for the specified type.
      *
+     * If one of the objects, returned from that method, implements the {@link Configurable} interface,
+     * then the factory will invoke the method {@link Configurable#configure(Conf)} with the given {@link Conf}.
+     * For a shared object, the method will be invoked only the first time it is returned.
+     *
      * @param type   the fully qualified class name or an alias of the component.
      * @param conf   the configuration used if the component implement {@link Configurable}.
      * @param <T>    the component-type.
      *
-     * @return       all instances of type {@link T}.
+     * @return        all instances of type {@link T}.
      */
     <T> Collection<T> getAllComponents(final String type, final Conf conf);
 
     /**
      * Gets all instances, which may be shared or independent, for the specified type.
+     *
+     * If one of the objects, returned from that method, implements the {@link Configurable} interface,
+     * then the factory will invoke the method {@link Configurable#configure(Conf)} with the given {@link Conf}.
+     * For a shared object, the method will be invoked only the first time it is returned.
      *
      * @param type       the fully qualified class name or an alias of the component.
      * @param conf       the configuration used if the component implement {@link Configurable}.
@@ -159,6 +179,10 @@ public interface ComponentFactory extends ComponentRegistry, ComponentDescriptor
     /**
      * Gets all instances, which may be shared or independent, for the specified type.
      *
+     * If one of the objects, returned from that method, implements the {@link Configurable} interface,
+     * then the factory will invoke the method {@link Configurable#configure(Conf)} with the given {@link Conf}.
+     * For a shared object, the method will be invoked only the first time it is returned.
+     *
      * @param type    the component class.
      * @param conf    the configuration used if the component implement {@link Configurable}.
      * @param <T>     the component-type.
@@ -170,8 +194,13 @@ public interface ComponentFactory extends ComponentRegistry, ComponentDescriptor
     /**
      * Gets all instances, which may be shared or independent, for the specified type.
      *
+     * If one of the objects, returned from that method, implements the {@link Configurable} interface,
+     * then the factory will invoke the method {@link Configurable#configure(Conf)} with the given {@link Conf}.
+     * For a shared object, the method will be invoked only the first time it is returned.
+     *
      * @param type       the component class.
      * @param conf       the configuration used if the component implement {@link Configurable}.
+     * @param conf       the {@link Conf} that may be used to match components {@link Condition}.
      * @param qualifier  the options used to qualify the component.
      * @param <T>        the component-type.
      *
@@ -188,7 +217,8 @@ public interface ComponentFactory extends ComponentRegistry, ComponentDescriptor
      *
      * @return           all instances of type {@link T}.
      */
-    <T> Collection<GettableComponent<T>> getAllComponents(final Class<T> type, final Qualifier<T> qualifier);
+    <T> Collection<GettableComponent<T>> getAllComponentProviders(final Class<T> type,
+                                                                  final Qualifier<T> qualifier);
 
     @Override
     void close() throws IOException;

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentRegistry.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentRegistry.java
@@ -33,7 +33,7 @@ public interface ComponentRegistry {
      * @param modifiers         the component descriptor modifiers.
      * @param <T>               the component-type.
      *
-     * @throws ConflictingBeanDefinitionException if a component is already register for that descriptor.
+     * @throws ConflictingComponentDefinitionException if a component is already register for that descriptor.
      */
     default <T> void registerComponent(final Class<T> componentClass,
                                        final Supplier<T> supplier,
@@ -50,7 +50,7 @@ public interface ComponentRegistry {
      * @param modifiers         the component descriptor modifiers.
      * @param <T>               the component-type.
      *
-     * @throws ConflictingBeanDefinitionException if a component is already register for that descriptor.
+     * @throws ConflictingComponentDefinitionException if a component is already register for that descriptor.
      */
     <T> void registerComponent(final String componentName,
                                final Class<T> componentClass,
@@ -63,7 +63,7 @@ public interface ComponentRegistry {
      * @param componentClass    the class-type of the component.
      * @param <T>               the component-type.
      *
-     * @throws ConflictingBeanDefinitionException if a component is already register for that descriptor.
+     * @throws ConflictingComponentDefinitionException if a component is already register for that descriptor.
      */
     default <T> void registerComponent(final Class<T> componentClass,
                                        final ComponentDescriptorModifier... modifiers) {
@@ -77,7 +77,7 @@ public interface ComponentRegistry {
      * @param componentClass    the class-type of the component.
      * @param <T>               the component-type.
      *
-     * @throws ConflictingBeanDefinitionException if a component is already register for that descriptor.
+     * @throws ConflictingComponentDefinitionException if a component is already register for that descriptor.
      */
     <T> void registerComponent(final String componentName,
                                final Class<T> componentClass,
@@ -91,7 +91,7 @@ public interface ComponentRegistry {
      * @param singleton         the supplier of the component.
      * @param <T>               the component-type.
      *
-     * @throws ConflictingBeanDefinitionException if a component is already register for that descriptor.
+     * @throws ConflictingComponentDefinitionException if a component is already register for that descriptor.
      */
     default <T> void registerSingleton(final Class<T> componentClass,
                                        final Supplier<T> singleton,
@@ -108,7 +108,7 @@ public interface ComponentRegistry {
      * @param singleton         the supplier of the component.
      * @param <T>               the component-type.
      *
-     * @throws ConflictingBeanDefinitionException if a component is already register for that descriptor.
+     * @throws ConflictingComponentDefinitionException if a component is already register for that descriptor.
      */
     <T> void registerSingleton(final String componentName,
                                final Class<T> componentClass,
@@ -121,7 +121,7 @@ public interface ComponentRegistry {
      * @param componentClass    the class-type of the component.
      * @param <T>               the component-type.
      *
-     * @throws ConflictingBeanDefinitionException if a component is already register for that descriptor.
+     * @throws ConflictingComponentDefinitionException if a component is already register for that descriptor.
      */
     default <T> void registerSingleton(final Class<T> componentClass,
                                        final ComponentDescriptorModifier... modifiers) {
@@ -135,7 +135,7 @@ public interface ComponentRegistry {
      * @param componentClass    the class-type of the component.
      * @param <T>               the component-type.
      *
-     * @throws ConflictingBeanDefinitionException if a component is already register for that descriptor.
+     * @throws ConflictingComponentDefinitionException if a component is already register for that descriptor.
      */
     <T> void registerSingleton(final String componentName,
                                final Class<T> componentClass,
@@ -147,7 +147,7 @@ public interface ComponentRegistry {
      * @param singleton the singleton component instance.
      * @param <T>       the component-type.
      *
-     * @throws ConflictingBeanDefinitionException if a component is already register for that descriptor.
+     * @throws ConflictingComponentDefinitionException if a component is already register for that descriptor.
      */
     <T> void registerSingleton(final T singleton);
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ConditionalDescriptorRegistry.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ConditionalDescriptorRegistry.java
@@ -18,20 +18,18 @@
  */
 package io.streamthoughts.azkarra.api.components;
 
+import io.streamthoughts.azkarra.api.components.condition.ComponentConditionalContext;
+
 import java.util.Collection;
 import java.util.Optional;
 
-public interface ComponentDescriptorRegistry {
-
-    /**
-     * Finds all {@link ComponentDescriptor} registered for the specified type.
-     *
-     * @param type      the component class.
-     * @param <T>       the component type.
-     *
-     * @return          the collection of {@link ComponentDescriptor}.
-     */
-    <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByClass(final Class<T> type);
+/**
+ * The main interface that defines methods to find registered {@link ComponentDescriptor} for
+ * enable components.
+ *
+ * @see io.streamthoughts.azkarra.api.components.condition.Condition
+ */
+public interface ConditionalDescriptorRegistry {
 
     /**
      * Finds all {@link ComponentDescriptor} registered for the specified type.
@@ -42,6 +40,18 @@ public interface ComponentDescriptorRegistry {
      * @return          the collection of {@link ComponentDescriptor}.
      */
     <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByClass(final Class<T> type,
+                                                                     final ComponentConditionalContext context);
+
+    /**
+     * Finds all {@link ComponentDescriptor} registered for the specified type.
+     *
+     * @param type      the component class.
+     * @param <T>       the component type.
+     *
+     * @return          the collection of {@link ComponentDescriptor}.
+     */
+    <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByClass(final Class<T> type,
+                                                                     final ComponentConditionalContext context,
                                                                      final Qualifier<T> qualifier);
 
     /**
@@ -53,7 +63,8 @@ public interface ComponentDescriptorRegistry {
      * @return          the collection of {@link ComponentDescriptor}.
      *
      */
-    <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByAlias(final String alias);
+    <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByAlias(final String alias,
+                                                                     final ComponentConditionalContext context);
 
     /**
      * Finds all {@link ComponentDescriptor} registered for the specified alias.
@@ -65,6 +76,7 @@ public interface ComponentDescriptorRegistry {
      *
      */
     <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByAlias(final String alias,
+                                                                     final ComponentConditionalContext context,
                                                                      final Qualifier<T> qualifier);
 
     /**
@@ -78,7 +90,8 @@ public interface ComponentDescriptorRegistry {
      * @throws NoUniqueComponentException   if more than one component is registered for the given type.
      *
      */
-    <T> Optional<ComponentDescriptor<T>> findDescriptorByAlias(final String alias) ;
+    <T> Optional<ComponentDescriptor<T>> findDescriptorByAlias(final String alias,
+                                                               final ComponentConditionalContext context) ;
 
     /**
      * Finds a {@link ComponentDescriptor} for the specified type and options.
@@ -91,6 +104,7 @@ public interface ComponentDescriptorRegistry {
      * @throws NoUniqueComponentException   if more than one component is registered for the given type.
      */
     <T> Optional<ComponentDescriptor<T>> findDescriptorByAlias(final String alias,
+                                                               final ComponentConditionalContext context,
                                                                final Qualifier<T> qualifier);
 
     /**
@@ -102,7 +116,8 @@ public interface ComponentDescriptorRegistry {
      * @return           the optional {@link ComponentDescriptor} instance.
      * @throws NoUniqueComponentException   if more than one component is registered for the given type.
      */
-    <T> Optional<ComponentDescriptor<T>> findDescriptorByClass(final Class<T> type);
+    <T> Optional<ComponentDescriptor<T>> findDescriptorByClass(final Class<T> type,
+                                                               final ComponentConditionalContext context);
 
     /**
      * Finds a {@link ComponentDescriptor} for the specified type and options.
@@ -115,15 +130,6 @@ public interface ComponentDescriptorRegistry {
      * @throws NoUniqueComponentException   if more than one component is registered for the given type.
      */
     <T> Optional<ComponentDescriptor<T>> findDescriptorByClass(final Class<T> type,
+                                                               final ComponentConditionalContext context,
                                                                final Qualifier<T> qualifier);
-
-    /**
-     * Registers the specified {@link ComponentDescriptor} to this {@link ComponentRegistry}.
-     *
-     * @param descriptor    the {@link ComponentDescriptor} instance to be registered.
-     * @param <T>           the component type.
-     *
-     * @throws ConflictingComponentDefinitionException if a component is already register for that descriptor.
-     */
-    <T> void registerDescriptor(final ComponentDescriptor<T> descriptor);
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ConfigurableComponentFactory.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ConfigurableComponentFactory.java
@@ -49,7 +49,7 @@ public interface ConfigurableComponentFactory {
      * @throws NoUniqueComponentException   if more than one component is registered for the given type.
      * @throws NoSuchComponentException     if no component is registered for the given type.
      */
-    default <T> T  getComponent(final Class<T> type) {
+    default <T> T getComponent(final Class<T> type) {
         return getComponentFactory().getComponent(type, getConfiguration());
     }
 

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ConflictingComponentDefinitionException.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ConflictingComponentDefinitionException.java
@@ -18,22 +18,16 @@
  */
 package io.streamthoughts.azkarra.api.components;
 
-/**
- * @see io.streamthoughts.azkarra.api.annotations.Order
- */
-public interface Ordered extends Comparable<Ordered> {
+import io.streamthoughts.azkarra.api.errors.AzkarraException;
 
-    int HIGHEST_ORDER = Integer.MIN_VALUE;
-
-    int LOWEST_ORDER = Integer.MAX_VALUE;
-
-    int order();
+public class ConflictingComponentDefinitionException extends AzkarraException {
 
     /**
-     * {@inheritDoc}
+     * Creates a new {@link ConflictingComponentDefinitionException} instance.
+     *
+     * @param message   the error message.
      */
-    @Override
-    default int compareTo(final Ordered that) {
-        return Integer.compare(this.order(), that.order());
+    public ConflictingComponentDefinitionException(final String message) {
+        super(message);
     }
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ContextAwareComponentFactory.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ContextAwareComponentFactory.java
@@ -22,17 +22,13 @@ import io.streamthoughts.azkarra.api.AzkarraContext;
 import io.streamthoughts.azkarra.api.AzkarraContextAware;
 import io.streamthoughts.azkarra.api.config.Conf;
 
-import java.io.IOException;
 import java.util.Collection;
-import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class ContextAwareComponentFactory implements ComponentFactory {
+public class ContextAwareComponentFactory extends DelegatingComponentFactory {
 
     private final AzkarraContext context;
-
-    private final ComponentFactory factory;
 
     /**
      * Creates a new {@link ContextAwareComponentFactory} instance.
@@ -41,41 +37,10 @@ public class ContextAwareComponentFactory implements ComponentFactory {
      */
     public ContextAwareComponentFactory(final AzkarraContext context,
                                         final ComponentFactory factory) {
-        this.context = context;
-        this.factory = factory;
+        super(factory);
+        this.context = Objects.requireNonNull(context, "context cannot be null");
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean containsComponent(final String alias) {
-        return factory.containsComponent(alias);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> boolean containsComponent(final String alias, final Qualifier<T> qualifier) {
-        return factory.containsComponent(alias, qualifier);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> boolean containsComponent(final Class<T> type) {
-        return factory.containsComponent(type);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> boolean containsComponent(final Class<T> type, final Qualifier<T> qualifier) {
-        return factory.containsComponent(type, qualifier);
-    }
 
     /**
      * {@inheritDoc}
@@ -93,13 +58,6 @@ public class ContextAwareComponentFactory implements ComponentFactory {
         return maySetContextAndGet(factory.getComponent(type, conf, qualifier));
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> GettableComponent<T> getComponent(final Class<T> type, final Qualifier<T> qualifier) {
-        return factory.getComponent(type, qualifier);
-    }
 
     /**
      * {@inheritDoc}
@@ -153,148 +111,6 @@ public class ContextAwareComponentFactory implements ComponentFactory {
                                               final Qualifier<T> qualifier) {
         Collection<T> components = factory.getAllComponents(type, conf);
         return components.stream().map(this::maySetContextAndGet).collect(Collectors.toList());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> Collection<GettableComponent<T>> getAllComponents(final Class<T> type, final Qualifier<T> qualifier) {
-        return factory.getAllComponents(type, qualifier);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> void registerComponent(final String componentName,
-                                      final Class<T> componentClass,
-                                      final Supplier<T> supplier,
-                                      final ComponentDescriptorModifier... modifiers) {
-        factory.registerSingleton(componentName, componentClass, supplier, modifiers);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> void registerComponent(final String componentName,
-                                      final Class<T> componentClass,
-                                      final ComponentDescriptorModifier... modifiers) {
-        factory.registerComponent(componentName, componentClass, modifiers);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> void registerSingleton(final String componentName,
-                                      final Class<T> componentClass,
-                                      final Supplier<T> singleton,
-                                      final ComponentDescriptorModifier... modifiers) {
-        factory.registerSingleton(componentName, componentClass, singleton, modifiers);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> void registerSingleton(final String componentName,
-                                      final Class<T> componentClass,
-                                      final ComponentDescriptorModifier... modifiers) {
-        factory.registerSingleton(componentName, componentClass, modifiers);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> void registerSingleton(final T singleton) {
-        factory.registerSingleton(singleton);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void close() throws IOException {
-        factory.close();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByClass(final Class<T> type) {
-        return factory.findAllDescriptorsByClass(type);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByClass(final Class<T> type,
-                                                                            final Qualifier<T> qualifier) {
-        return factory.findAllDescriptorsByClass(type, qualifier);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByAlias(final String alias) {
-        return factory.findAllDescriptorsByAlias(alias);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByAlias(final String alias,
-                                                                            final Qualifier<T> qualifier) {
-        return factory.findAllDescriptorsByAlias(alias, qualifier);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> Optional<ComponentDescriptor<T>> findDescriptorByAlias(final String alias) {
-        return factory.findDescriptorByAlias(alias);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> Optional<ComponentDescriptor<T>> findDescriptorByAlias(final String alias,
-                                                                      final Qualifier<T> qualifier) {
-        return factory.findDescriptorByAlias(alias, qualifier);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> Optional<ComponentDescriptor<T>> findDescriptorByClass(final Class<T> type) {
-        return factory.findDescriptorByClass(type);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> Optional<ComponentDescriptor<T>> findDescriptorByClass(final Class<T> type,
-                                                                      final Qualifier<T> qualifier) {
-        return factory.findDescriptorByClass(type, qualifier);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> void registerDescriptor(final ComponentDescriptor<T> descriptor) {
-        factory.registerDescriptor(descriptor);
     }
 
     private <T> T maySetContextAndGet(final T component) {

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/DelegatingComponentFactory.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/DelegatingComponentFactory.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.azkarra.api.components;
+
+import io.streamthoughts.azkarra.api.components.condition.ComponentConditionalContext;
+import io.streamthoughts.azkarra.api.config.Conf;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * A delegating {@link ComponentFactory} implementation.
+ */
+public class DelegatingComponentFactory implements ComponentFactory {
+
+    protected final ComponentFactory factory;
+
+    protected DelegatingComponentFactory(final ComponentFactory factory) {
+        this.factory = Objects.requireNonNull(factory, "factory cannot be null");
+    }
+
+    @Override
+    public boolean containsComponent(final String type) {
+        return factory.containsComponent(type);
+    }
+
+    @Override
+    public <T> boolean containsComponent(final String type,
+                                         final Qualifier<T> qualifier) {
+        return factory.containsComponent(type, qualifier);
+    }
+
+    @Override
+    public <T> boolean containsComponent(final Class<T> type) {
+        return factory.containsComponent(type);
+    }
+
+    @Override
+    public <T> boolean containsComponent(final Class<T> type, final Qualifier<T> qualifier) {
+        return factory.containsComponent(type, qualifier);
+    }
+
+    @Override
+    public <T> T getComponent(final Class<T> type, final Conf conf) {
+        return factory.getComponent(type, conf);
+    }
+
+    @Override
+    public <T> T getComponent(final Class<T> type, final Conf conf, final Qualifier<T> qualifier) {
+        return factory.getComponent(type, conf, qualifier);
+    }
+
+    @Override
+    public <T> GettableComponent<T> getComponentProvider(final Class<T> type, final Qualifier<T> qualifier) {
+        return factory.getComponentProvider(type, qualifier);
+    }
+
+    @Override
+    public <T> T getComponent(final String type, final Conf conf) {
+        return factory.getComponent(type, conf);
+    }
+
+    @Override
+    public <T> T getComponent(final String type, final Conf conf, final Qualifier<T> qualifier) {
+        return factory.getComponent(type, conf, qualifier);
+    }
+
+    @Override
+    public <T> Collection<T> getAllComponents(final String type, final Conf conf) {
+        return factory.getAllComponents(type, conf);
+    }
+
+    @Override
+    public <T> Collection<T> getAllComponents(final String type, final Conf conf, final Qualifier<T> qualifier) {
+        return factory.getAllComponents(type, conf, qualifier);
+    }
+
+    @Override
+    public <T> Collection<T> getAllComponents(final Class<T> type, final Conf conf) {
+        return factory.getAllComponents(type, conf);
+    }
+
+    @Override
+    public <T> Collection<T> getAllComponents(final Class<T> type, final Conf conf,
+                                              final Qualifier<T> qualifier) {
+        return factory.getAllComponents(type, conf, qualifier);
+    }
+
+    @Override
+    public <T> Collection<GettableComponent<T>> getAllComponentProviders(final Class<T> type,
+                                                                         final Qualifier<T> qualifier) {
+        return factory.getAllComponentProviders(type, qualifier);
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.factory.close();
+    }
+
+    @Override
+    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByClass(final Class<T> type) {
+        return factory.findAllDescriptorsByClass(type);
+    }
+
+    @Override
+    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByClass(final Class<T> type,
+                                                                            final Qualifier<T> qualifier) {
+        return factory.findAllDescriptorsByClass(type, qualifier);
+    }
+
+    @Override
+    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByAlias(final String alias) {
+        return factory.findAllDescriptorsByAlias(alias);
+    }
+
+    @Override
+    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByAlias(final String alias,
+                                                                            final Qualifier<T> qualifier) {
+        return factory.findAllDescriptorsByAlias(alias, qualifier);
+    }
+
+    @Override
+    public <T> Optional<ComponentDescriptor<T>> findDescriptorByAlias(final String alias) {
+        return factory.findDescriptorByAlias(alias);
+    }
+
+    @Override
+    public <T> Optional<ComponentDescriptor<T>> findDescriptorByAlias(final String alias,
+                                                                      final Qualifier<T> qualifier) {
+        return factory.findDescriptorByAlias(alias, qualifier);
+    }
+
+    @Override
+    public <T> Optional<ComponentDescriptor<T>> findDescriptorByClass(final Class<T> type) {
+        return factory.findDescriptorByClass(type);
+    }
+
+    @Override
+    public <T> Optional<ComponentDescriptor<T>> findDescriptorByClass(final Class<T> type,
+                                                                      final Qualifier<T> qualifier) {
+        return factory.findDescriptorByClass(type, qualifier);
+    }
+
+    @Override
+    public <T> void registerDescriptor(final ComponentDescriptor<T> descriptor) {
+        factory.registerDescriptor(descriptor);
+    }
+
+    @Override
+    public <T> void registerComponent(final String componentName,
+                                      final Class<T> componentClass,
+                                      final Supplier<T> supplier,
+                                      final ComponentDescriptorModifier... modifiers) {
+        factory.registerComponent(componentName, componentClass, supplier, modifiers);
+    }
+
+    @Override
+    public <T> void registerComponent(final String componentName,
+                                      final Class<T> componentClass,
+                                      final ComponentDescriptorModifier... modifiers) {
+        factory.registerComponent(componentName, componentClass, modifiers);
+    }
+
+    @Override
+    public <T> void registerSingleton(final String componentName,
+                                      final Class<T> componentClass,
+                                      final Supplier<T> singleton,
+                                      final ComponentDescriptorModifier... modifiers) {
+        factory.registerComponent(componentName, componentClass, singleton, modifiers);
+    }
+
+    @Override
+    public <T> void registerSingleton(final String componentName,
+                                      final Class<T> componentClass,
+                                      final ComponentDescriptorModifier... modifiers) {
+        factory.registerSingleton(componentName, componentClass, modifiers);
+    }
+
+    @Override
+    public <T> void registerSingleton(final T singleton) {
+        factory.registerSingleton(singleton);
+    }
+
+    @Override
+    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByClass(final Class<T> type,
+                                                                            final ComponentConditionalContext context){
+        return factory.findAllDescriptorsByClass(type, context);
+    }
+
+    @Override
+    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByClass(final Class<T> type,
+                                                                            final ComponentConditionalContext context,
+                                                                            final Qualifier<T> qualifier) {
+        return factory.findAllDescriptorsByClass(type, context, qualifier);
+    }
+
+    @Override
+    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByAlias(final String alias,
+                                                                            final ComponentConditionalContext context){
+        return factory.findAllDescriptorsByAlias(alias, context);
+    }
+
+    @Override
+    public <T> Collection<ComponentDescriptor<T>> findAllDescriptorsByAlias(final String alias,
+                                                                            final ComponentConditionalContext context,
+                                                                            final Qualifier<T> qualifier) {
+        return factory.findAllDescriptorsByAlias(alias, context, qualifier);
+    }
+
+    @Override
+    public <T> Optional<ComponentDescriptor<T>> findDescriptorByAlias(final String alias,
+                                                                      final ComponentConditionalContext context) {
+        return factory.findDescriptorByAlias(alias, context);
+    }
+
+    @Override
+    public <T> Optional<ComponentDescriptor<T>> findDescriptorByAlias(final String alias,
+                                                                      final ComponentConditionalContext context,
+                                                                      final Qualifier<T> qualifier) {
+        return factory.findDescriptorByAlias(alias, context, qualifier);
+    }
+
+    @Override
+    public <T> Optional<ComponentDescriptor<T>> findDescriptorByClass(final Class<T> type,
+                                                                      final ComponentConditionalContext context) {
+        return factory.findDescriptorByClass(type, context);
+    }
+
+    @Override
+    public <T> Optional<ComponentDescriptor<T>> findDescriptorByClass(final Class<T> type,
+                                                                      final ComponentConditionalContext context,
+                                                                      final Qualifier<T> qualifier) {
+        return factory.findDescriptorByClass(type, context, qualifier);
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/SimpleComponentDescriptor.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/SimpleComponentDescriptor.java
@@ -18,9 +18,11 @@
  */
 package io.streamthoughts.azkarra.api.components;
 
+import io.streamthoughts.azkarra.api.components.condition.Condition;
 import io.streamthoughts.azkarra.api.util.Version;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Supplier;
@@ -52,6 +54,10 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
 
     private final boolean isSecondary;
 
+    private final Condition condition;
+
+    private final boolean isConditional;
+
     private final int order;
 
     /**
@@ -66,7 +72,18 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
                                      final Class<T> type,
                                      final Supplier<T> supplier,
                                      final boolean isSingleton) {
-        this(name, type, type.getClassLoader(), supplier, null, isSingleton, false, false, Ordered.LOWEST_ORDER);
+        this(
+            name,
+            type,
+            type.getClassLoader(),
+            supplier,
+            null,
+            isSingleton,
+            false,
+            false,
+            null,
+            Ordered.LOWEST_ORDER
+        );
     }
 
     /**
@@ -83,7 +100,18 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
                                      final Supplier<T> supplier,
                                      final String version,
                                      final boolean isSingleton) {
-        this(name, type, type.getClassLoader(), supplier, version, isSingleton, false, false, Ordered.LOWEST_ORDER);
+        this(
+            name,
+            type,
+            type.getClassLoader(),
+            supplier,
+            version,
+            isSingleton,
+            false,
+            false,
+            null,
+            Ordered.LOWEST_ORDER
+        );
     }
 
     /**
@@ -104,6 +132,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
                                      final boolean isSingleton,
                                      final boolean isPrimary,
                                      final boolean isSecondary,
+                                     final Condition condition,
                                      final int order) {
         Objects.requireNonNull(type, "type can't be null");
         Objects.requireNonNull(supplier, "supplier can't be null");
@@ -117,6 +146,8 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
         this.isSingleton = isSingleton;
         this.isPrimary = isPrimary;
         this.isSecondary = isSecondary;
+        this.isConditional = condition != null;
+        this.condition = condition;
         this.order = order;
     }
 
@@ -135,6 +166,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
             descriptor.isSingleton(),
             descriptor.isPrimary(),
             descriptor.isSecondary(),
+            descriptor.condition().orElse(null),
             descriptor.order()
         );
         metadata = descriptor.metadata();
@@ -245,6 +277,14 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
      * {@inheritDoc}
      */
     @Override
+    public Optional<Condition> condition() {
+        return Optional.ofNullable(condition);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public int order() {
         return order;
     }
@@ -261,6 +301,8 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
                 ", aliases=" + aliases +
                 ", isSingleton=" + isSingleton +
                 ", isPrimary=" + isPrimary +
+                ", isSecondary=" + isSecondary +
+                ", isConditional=" + isConditional +
                 ", metadata=" + metadata +
                 ", order=" + order +
                 ']';

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/ComponentConditionalContext.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/ComponentConditionalContext.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.azkarra.api.components.condition;
+
+import io.streamthoughts.azkarra.api.components.ComponentDescriptor;
+import io.streamthoughts.azkarra.api.components.ComponentFactory;
+
+/**
+ * Interface to verify if a conditional component is enabled for a given context.
+ *
+ * @see Condition
+ * @see ConditionContext
+ * @see io.streamthoughts.azkarra.api.components.ConditionalDescriptorRegistry
+ */
+@FunctionalInterface
+public interface ComponentConditionalContext<T extends ComponentDescriptor>{
+
+    /**
+     * Verify if this component is enabled for the given context.
+     *
+     * @param factory       the {@link ComponentFactory}; cannot be {@code null}.
+     * @param descriptor    the {@link ComponentDescriptor}; cannot be {@code null}.
+     *
+     * @return              {@code true} if the compoenent is enable.
+     */
+    boolean isEnable(final ComponentFactory factory,
+                     final T descriptor);
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/Condition.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/Condition.java
@@ -16,24 +16,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.components;
+package io.streamthoughts.azkarra.api.components.condition;
+
+import java.util.function.Predicate;
 
 /**
- * @see io.streamthoughts.azkarra.api.annotations.Order
+ * Define a single condition that need to be fulfilled for a component to be eligible for use in the application.
  */
-public interface Ordered extends Comparable<Ordered> {
+@FunctionalInterface
+public interface Condition extends Predicate<ConditionContext> {
 
-    int HIGHEST_ORDER = Integer.MIN_VALUE;
-
-    int LOWEST_ORDER = Integer.MAX_VALUE;
-
-    int order();
+    Condition True = new TrueCondition();
 
     /**
-     * {@inheritDoc}
+     * Verifies if the condition matches.
+     *
+     * @param context    the {@link ConditionContext}.
+     *
+     * @return           {@code true} if the component matches this condition, {@code false} otherwise.
      */
+    boolean matches(final ConditionContext context);
+
     @Override
-    default int compareTo(final Ordered that) {
-        return Integer.compare(this.order(), that.order());
+    default boolean test(final ConditionContext context) {
+        return matches(context);
     }
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/ConditionContext.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/ConditionContext.java
@@ -16,41 +16,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.components;
+package io.streamthoughts.azkarra.api.components.condition;
 
-import io.streamthoughts.azkarra.api.components.condition.ComponentConditionalContext;
+import io.streamthoughts.azkarra.api.components.ComponentDescriptor;
+import io.streamthoughts.azkarra.api.components.ComponentFactory;
 import io.streamthoughts.azkarra.api.config.Conf;
-import io.streamthoughts.azkarra.api.config.Configurable;
 
 /**
- * Class for getting a configurable component.
- *
- * @param <T>   the component-type.
+ * The context information for use by a {@link Condition} matching a {@link ComponentDescriptor}.
+ * 
+ * @see Condition#matches(ConditionContext).
  */
-public interface GettableComponent<T> extends AutoCloseable {
+public interface ConditionContext<T extends ComponentDescriptor> {
 
     /**
-     * Gets the instance of type {@link T}, which may be shared or independent.
+     * Get the {@link ComponentFactory} that holds the component descriptor should the condition match.
+     * The returned registry should not be used to register a new component descriptor.
      *
-     * @param conf  the configuration to be used if the component implement {@link Configurable}.
-     *
-     * @return  the component of type {@link T}.
+     * @return  the {@link ComponentFactory}; cannot be {@code null}.
      */
-    T get(final Conf conf);
-
-    boolean isEnable(final ComponentConditionalContext<ComponentDescriptor<T>> conditionalContext);
-
-    boolean isUnique();
+    ComponentFactory getComponentFactory();
 
     /**
-     * Gets the descriptor for the component.
+     * Get the configuration that was passed to get the component instance.
      *
-     * @return  the {@link ComponentDescriptor}.
+     * @return  the {@link Conf} object; cannot be {@code null}.
      */
-    ComponentDescriptor<T> descriptor();
+    Conf getConfig();
 
     /**
-     * Closes the created component.
+     * @return the component that should match the condition.
      */
-    void close();
+    T getComponent();
+
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/Conditions.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/Conditions.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.components.condition;
+
+import io.streamthoughts.azkarra.api.annotations.ConditionalOn;
+import io.streamthoughts.azkarra.api.util.ClassUtils;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public final class Conditions {
+
+    /**
+     * Static helper method to create a {@link Condition} compose of the given ones.
+     *
+     * @param conditions    the {@link Condition}s to compose.
+     *
+     * @return              the new {@link Condition} object.
+     */
+    public static Condition compose(final List<? extends Condition> conditions) {
+        return new CompositeCondition(conditions);
+    }
+
+    /**
+     * Static helper method to create a {@link Condition} compose of the given ones.
+     *
+     * @param conditions    the {@link Condition}s to compose.
+     *
+     * @return              the new {@link Condition} object.
+     */
+    public static Condition compose(final Condition ...conditions) {
+        return new CompositeCondition(List.of(conditions));
+    }
+
+
+    /**
+     * Specify that the given property should be set for a component to be eligible for use.
+     * .
+     * @param property  the property name.
+     * @return          the {@link Condition} object.
+     */
+    public static Condition onPropertyExist(final String property) {
+        return OnPropertyCondition.ofTypeString(property, Optional::isPresent);
+    }
+
+    /**
+     * Specify that the given property should be missing for a component to be eligible for use.
+     *
+     * @param property  the property name.
+     * @return          the {@link Condition} object.
+     */
+    public static Condition onPropertyMissing(final String property) {
+        return OnPropertyCondition.ofTypeString(property, Optional::isEmpty);
+    }
+
+    /**
+     * Specify that the given property should be equal to the given value for a component to be eligible for use.
+     *
+     * @param property  the property name.
+     * @return          the {@link Condition} object.
+     */
+    public static Condition onPropertyEquals(final String property, final String value) {
+        final Predicate<Optional<String>> predicate = opt -> opt.map(s -> s.equals(value)).orElse(false);
+        return OnPropertyCondition.ofTypeString(property, predicate);
+    }
+
+    /**
+     * Specify that the given property should be equal to the given value for a component to be eligible for use.
+     *
+     * @param property  the property name.
+     * @return          the {@link Condition} object.
+     */
+    public static Condition onPropertyNotEquals(final String property, final String value) {
+        final Predicate<Optional<String>> predicate = opt -> opt.map(s -> !s.equals(value)).orElse(false);
+        return OnPropertyCondition.ofTypeString(property, predicate);
+    }
+
+    /**
+     * Specify that the given property should be matched the given pattern for a component to be eligible for use.
+     *
+     * @param property  the property name.
+     * @return          the {@link Condition} object.
+     */
+    public static Condition onPropertyMatches(final String property, final String pattern) {
+        var match = Pattern.compile(pattern).asMatchPredicate();
+        return OnPropertyCondition.ofTypeString(property, opt -> opt.map(match::test).orElse(false));
+    }
+
+    /**
+     * Specify that the given property should be {@code true} for a component to be eligible for use.
+     *
+     * @param property  the property name.
+     * @return          the {@link Condition} object.
+     */
+    public static Condition onPropertyTrue(final String property) {
+        return OnPropertyCondition.ofTypeBoolean(property, opt -> opt.orElse(false));
+    }
+
+    /**
+     * Specify that components of the given types must be registered for the component to be enabled.
+     *
+     * @param types  the components that should be registered.
+     * @return       the {@link Condition} object.
+     */
+    public static Condition onComponents(final List<Class> types) {
+        return new OnComponentCondition(types, true);
+    }
+
+    /**
+     * Specify that components of the given types must be missing for the component to be enabled.
+     *
+     * @param types  the components that should be missing.
+     * @return       the {@link Condition} object.
+     */
+    public static Condition onMissingComponent(final List<Class> types) {
+        return new OnComponentCondition(types, false);
+    }
+
+    /**
+     * Composite condition.
+     */
+    private static class CompositeCondition implements Condition {
+
+        final List<? extends Condition> conditions;
+
+        private CompositeCondition(final List<? extends Condition> conditions) {
+            this.conditions = Objects.requireNonNull(conditions);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean matches(final ConditionContext context) {
+            return conditions.stream().allMatch(cond -> cond.matches(context));
+        }
+    }
+
+    /**
+     * Static helper to build a list of {@link Condition}s based on the given annotation.
+     *
+     * @param annotations   the {@link ConditionalOn} annotations.
+     * @return              the {@link Condition}s.
+     */
+    public static List<Condition> buildConditionsForAnnotation(final List<ConditionalOn> annotations) {
+        List<Condition> allConditions = new LinkedList<>();
+        for (ConditionalOn conditional : annotations) {
+            for (Class<? extends Condition> conditionClass : conditional.conditions()) {
+                allConditions.add(ClassUtils.newInstance(conditionClass));
+            }
+            final var components = Arrays.asList(conditional.components());
+            if (!components.isEmpty()) {
+                allConditions.add(Conditions.onComponents(components));
+            }
+
+            final var missingComponents = Arrays.asList(conditional.missingComponents());
+            if (!missingComponents.isEmpty()) {
+                allConditions.add(Conditions.onMissingComponent(missingComponents));
+            }
+
+            final var property = conditional.property();
+            if (!property.isEmpty()) {
+                if (!conditional.havingValue().isEmpty()) {
+                    allConditions.add(Conditions.onPropertyEquals(property, conditional.havingValue()));
+                }
+                if (!conditional.matching().isEmpty()) {
+                    allConditions.add(Conditions.onPropertyMatches(property, conditional.matching()));
+                }
+                if (!conditional.notEquals().isEmpty()) {
+                    allConditions.add(Conditions.onPropertyNotEquals(property, conditional.notEquals()));
+                }
+            }
+            if (!conditional.missingProperty().isEmpty()) {
+                allConditions.add(Conditions.onPropertyMissing(property));
+            }
+        }
+        return allConditions;
+    }
+
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/OnComponentCondition.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/OnComponentCondition.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.azkarra.api.components.condition;
+
+import io.streamthoughts.azkarra.api.components.ComponentDescriptor;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public class OnComponentCondition implements Condition {
+
+    private final List<Class> types;
+    private final boolean exists;
+
+    /**
+     * Creates a new {@link OnComponentCondition} instance.
+     *
+     * @param exists
+     */
+    public OnComponentCondition(final List<Class> types, final boolean exists) {
+        this.exists = exists;
+        this.types = types;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean matches(final ConditionContext context) {
+        return exists ? verifyExists(context) : verifyIsMissing(context);
+    }
+
+    private boolean verifyExists(ConditionContext context) {
+        for (Class type : types) {
+            // verify that a component is available for the given type.
+            if (verify(type, context, true)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean verifyIsMissing(ConditionContext context) {
+        for (Class type : types) {
+            // verify that no component is available for the given type.
+            if (!verify(type, context, false)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean verify(final Class type,
+                           final ConditionContext context,
+                           final boolean exists) {
+        Collection<ComponentDescriptor> descriptors  = context.getComponentFactory().findAllDescriptorsByClass(type);
+        for (ComponentDescriptor descriptor : descriptors) {
+            Optional<Condition> optionalCond = descriptor.condition();
+            if (optionalCond.isPresent()) {
+                Condition condition = optionalCond.get();
+                if (condition.matches(context)) {
+                    return exists;
+                }
+            } else {
+                return exists;
+            }
+        }
+        return !exists;
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/OnPropertyCondition.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/OnPropertyCondition.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.components.condition;
+
+import io.streamthoughts.azkarra.api.config.Conf;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Condition to express a requirement for a given property.
+ */
+public class OnPropertyCondition<T> implements Condition {
+
+    private final Function<Conf, Optional<T>> accessor;
+
+    private final Predicate<Optional<T>> predicate;
+
+    static OnPropertyCondition<String> ofTypeString(final String property,
+                                                    final Predicate<Optional<String>> predicate) {
+        return new OnPropertyCondition<>(c -> c.getOptionalString(property), predicate);
+    }
+
+    static OnPropertyCondition<Boolean> ofTypeBoolean(final String property,
+                                                      final Predicate<Optional<Boolean>> predicate) {
+        return new OnPropertyCondition<>(c -> c.getOptionalBoolean(property), predicate);
+    }
+
+    /**
+     * Creates a new {@link OnPropertyCondition} instance.
+     *
+     * @param accessor  the property accessor.
+     * @param predicate the predicate the property should match.
+     */
+    public OnPropertyCondition(final Function<Conf, Optional<T>> accessor,
+                               final Predicate<Optional<T>> predicate) {
+        this.accessor = Objects.requireNonNull(accessor, "property cannot be null");
+        this.predicate = predicate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean matches(final ConditionContext context) {
+        Optional<T> optional = accessor.apply(context.getConfig());
+        return predicate.test(optional);
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/TrueCondition.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/condition/TrueCondition.java
@@ -16,24 +16,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.components;
+
+package io.streamthoughts.azkarra.api.components.condition;
 
 /**
- * @see io.streamthoughts.azkarra.api.annotations.Order
+ * Returns {@code true}.
  */
-public interface Ordered extends Comparable<Ordered> {
-
-    int HIGHEST_ORDER = Integer.MIN_VALUE;
-
-    int LOWEST_ORDER = Integer.MAX_VALUE;
-
-    int order();
+public class TrueCondition implements Condition {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    default int compareTo(final Ordered that) {
-        return Integer.compare(this.order(), that.order());
+    public boolean matches(final ConditionContext context) {
+        return true;
     }
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/streams/KafkaStreamsContainer.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/streams/KafkaStreamsContainer.java
@@ -28,7 +28,7 @@ import io.streamthoughts.azkarra.api.streams.consumer.ConsumerGroupOffsets;
 import io.streamthoughts.azkarra.api.streams.consumer.ConsumerLogOffsets;
 import io.streamthoughts.azkarra.api.streams.consumer.GlobalConsumerOffsetsRegistry;
 import io.streamthoughts.azkarra.api.streams.consumer.LogOffsetsFetcher;
-import io.streamthoughts.azkarra.api.streams.internal.InternalStreamsLifeCycleContext;
+import io.streamthoughts.azkarra.api.streams.internal.InternalStreamsLifecycleContext;
 import io.streamthoughts.azkarra.api.streams.topology.TopologyContainer;
 import io.streamthoughts.azkarra.api.streams.topology.TopologyMetadata;
 import io.streamthoughts.azkarra.api.time.Time;
@@ -149,7 +149,7 @@ public class KafkaStreamsContainer {
             LOG.info("Initializing KafkaStreams container (application.id={})", applicationId());
             StreamsLifecycleChain streamsLifeCycle = new InternalStreamsLifeCycleChain(
                 topologyContainer.interceptors().iterator(),
-                (interceptor, chain) -> interceptor.onStart(new InternalStreamsLifeCycleContext(this), chain),
+                (interceptor, chain) -> interceptor.onStart(new InternalStreamsLifecycleContext(this), chain),
                 () -> {
                     try {
                         LOG.info("Starting KafkaStreams (application.id={})", applicationId());
@@ -394,7 +394,7 @@ public class KafkaStreamsContainer {
             LOG.info("Closing KafkaStreams container (application.id={})", applicationId());
             StreamsLifecycleChain streamsLifeCycle = new InternalStreamsLifeCycleChain(
                 topologyContainer.interceptors().iterator(),
-                (interceptor, chain) -> interceptor.onStop(new InternalStreamsLifeCycleContext(this), chain),
+                (interceptor, chain) -> interceptor.onStop(new InternalStreamsLifecycleContext(this), chain),
                 () -> {
                     kafkaStreams.close();
                     if (cleanUp) {
@@ -529,8 +529,7 @@ public class KafkaStreamsContainer {
      * @param watcher   the {@link StateChangeWatcher} to be registered.
      */
     public void addStateChangeWatcher(final StateChangeWatcher watcher) {
-        Objects.requireNonNull(watcher, "Cannot register null watcher");
-        stateChangeWatchers.add(watcher);
+        stateChangeWatchers.add(Objects.requireNonNull(watcher, "Cannot register null watcher"));
     }
 
     void stateChanges(final StateChangeEvent stateChangeEvent) {

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/streams/internal/InternalStreamsLifecycleContext.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/streams/internal/InternalStreamsLifecycleContext.java
@@ -22,20 +22,24 @@ import io.streamthoughts.azkarra.api.StreamsLifecycleContext;
 import io.streamthoughts.azkarra.api.config.Conf;
 import io.streamthoughts.azkarra.api.streams.KafkaStreamsContainer;
 import io.streamthoughts.azkarra.api.streams.State;
+import io.streamthoughts.azkarra.api.util.Version;
 import org.apache.kafka.streams.TopologyDescription;
 
 import java.util.Objects;
 
-public class InternalStreamsLifeCycleContext implements StreamsLifecycleContext {
+/**
+ * Internal {@link StreamsLifecycleContext} implementation.
+ */
+public class InternalStreamsLifecycleContext implements StreamsLifecycleContext {
 
     private final KafkaStreamsContainer container;
 
     /**
-     * Creates a new {@link InternalStreamsLifeCycleContext} instance.
+     * Creates a new {@link InternalStreamsLifecycleContext} instance.
      *
      * @param container the {@link KafkaStreamsContainer} instance
      */
-    public InternalStreamsLifeCycleContext(final KafkaStreamsContainer container) {
+    public InternalStreamsLifecycleContext(final KafkaStreamsContainer container) {
         this.container = Objects.requireNonNull(container, "container cannot be null");
     }
 
@@ -43,7 +47,23 @@ public class InternalStreamsLifeCycleContext implements StreamsLifecycleContext 
      * {@inheritDoc}
      */
     @Override
-    public String getApplicationId() {
+    public String topologyName() {
+        return container.topologyMetadata().name();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Version topologyVersion() {
+        return Version.parse(container.topologyMetadata().version());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String applicationId() {
         return container.applicationId();
     }
 
@@ -51,7 +71,7 @@ public class InternalStreamsLifeCycleContext implements StreamsLifecycleContext 
      * {@inheritDoc}
      */
     @Override
-    public TopologyDescription getTopology() {
+    public TopologyDescription topologyDescription() {
         return container.topologyDescription();
     }
 
@@ -59,7 +79,7 @@ public class InternalStreamsLifeCycleContext implements StreamsLifecycleContext 
      * {@inheritDoc}
      */
     @Override
-    public Conf getStreamConfig() {
+    public Conf streamsConfig() {
         return container.streamsConfig();
     }
 
@@ -67,7 +87,7 @@ public class InternalStreamsLifeCycleContext implements StreamsLifecycleContext 
      * {@inheritDoc}
      */
     @Override
-    public State getState() {
+    public State streamsState() {
         return container.state().value();
     }
 
@@ -79,6 +99,18 @@ public class InternalStreamsLifeCycleContext implements StreamsLifecycleContext 
        container.setState(state);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addStateChangeWatcher(final KafkaStreamsContainer.StateChangeWatcher watcher) {
+        container.addStateChangeWatcher(watcher);
+    }
+
+    /**
+     * Return the container that is running the current {@link org.apache.kafka.streams.KafkaStreams} instance.
+     * @return  the {@link KafkaStreamsContainer}; cannot be {@code null}.
+     */
     public KafkaStreamsContainer container() {
         return container;
     }

--- a/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/components/ComponentDescriptorTest.java
+++ b/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/components/ComponentDescriptorTest.java
@@ -90,6 +90,7 @@ public class ComponentDescriptorTest {
                 true,
                 false,
                 false,
+                null,
                 order
         );
     }
@@ -104,6 +105,7 @@ public class ComponentDescriptorTest {
             true,
             false,
             false,
+            null,
             Ordered.LOWEST_ORDER
         );
     }

--- a/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/components/condition/ConditionsTest.java
+++ b/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/components/condition/ConditionsTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.azkarra.api.components.condition;
+
+import io.streamthoughts.azkarra.api.components.ComponentDescriptor;
+import io.streamthoughts.azkarra.api.components.ComponentFactory;
+import io.streamthoughts.azkarra.api.components.SimpleComponentDescriptor;
+import io.streamthoughts.azkarra.api.config.Conf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ConditionsTest {
+
+    @Test
+    public void shouldCompose() {
+        Assertions.assertTrue(Conditions
+            .compose(context -> true, context -> true)
+            .matches(contextWith(Conf.empty()))
+        );
+    }
+
+    @Test
+    public void shouldReturnTrueWhenConditionOnPropertyEqualsGivenMatchingContext() {
+        Assertions.assertTrue(Conditions
+            .onPropertyEquals("props", "val")
+            .matches(contextWith(Conf.with("props", "val")))
+        );
+    }
+
+    @Test
+    public void shouldReturnFalseWhenConditionOnPropertyEqualsGivenMatchingContext() {
+        Assertions.assertFalse(Conditions
+                .onPropertyEquals("props", "val")
+                .matches(contextWith(Conf.empty()))
+        );
+    }
+
+    @Test
+    public void shouldReturnTrueWhenConditionOnPropertyExistGivenMatchingContext() {
+        Assertions.assertTrue(Conditions
+                .onPropertyExist("props")
+                .matches(contextWith(Conf.with("props", "val")))
+        );
+    }
+
+    @Test
+    public void shouldReturnFalseWhenConditionOnPropertyExistGivenMatchingContext() {
+        Assertions.assertFalse(Conditions
+                .onPropertyExist("props")
+                .matches(contextWith(Conf.empty()))
+        );
+    }
+
+    @Test
+    public void shouldReturnTrueWhenConditionOnPropertyTrueGivenMatchingContext() {
+        Assertions.assertTrue(Conditions
+                .onPropertyTrue("props")
+                .matches(contextWith(Conf.with("props", "yes")))
+        );
+    }
+
+    @Test
+    public void shouldReturnFalseWhenConditionOnPropertyTrueGivenMatchingContext() {
+        Assertions.assertFalse(Conditions
+                .onPropertyTrue("props")
+                .matches(contextWith(Conf.empty()))
+        );
+    }
+
+    @Test
+    public void shouldReturnTrueWhenConditionOnPropertyMissingGivenMatchingContext() {
+        Assertions.assertTrue(Conditions
+                .onPropertyMissing("props")
+                .matches(contextWith(Conf.empty()))
+        );
+    }
+
+    @Test
+    public void shouldReturnFalseWhenConditionOnPropertyMissingGivenMatchingContext() {
+        Assertions.assertFalse(Conditions
+                .onPropertyMissing("props")
+                .matches(contextWith(Conf.with("props", "")))
+        );
+    }
+
+    @Test
+    public void shouldReturnTrueWhenConditionOnPropertyMatchesGivenMatchingContext() {
+        Assertions.assertTrue(Conditions
+                .onPropertyMatches("props", "^val.*")
+                .matches(contextWith(Conf.with("props", "value")))
+        );
+    }
+
+    @Test
+    public void shouldReturnFalseWhenConditionOnPropertyMatchesGivenMatchingContext() {
+        Assertions.assertFalse(Conditions
+                .onPropertyMatches("props", "^val.*")
+                .matches(contextWith(Conf.with("props", "foo")))
+        );
+    }
+
+    @Test
+    public void shouldReturnTrueWhenConditionOnComponentGivenRegistered() {
+        ComponentFactory mkFactory = Mockito.mock(ComponentFactory.class);
+        ComponentDescriptor<ConditionsTest> descriptor = new SimpleComponentDescriptor<>("any", ConditionsTest.class, () -> null, true);
+        Mockito.when(mkFactory.findAllDescriptorsByClass(Mockito.same(ConditionsTest.class))).thenReturn(List.of(descriptor));
+        Assertions.assertTrue(Conditions
+            .onComponents(List.of(ConditionsTest.class))
+            .matches(contextWith(mkFactory))
+        );
+    }
+
+    @Test
+    public void shouldReturnFalseWhenConditionOnComponentGivenEmpty() {
+        ComponentFactory mkFactory = Mockito.mock(ComponentFactory.class);
+        Mockito.when(mkFactory.findAllDescriptorsByClass(Mockito.same(ConditionsTest.class))).thenReturn(Collections.emptyList());
+        Assertions.assertFalse(Conditions
+                .onComponents(List.of(ConditionsTest.class))
+                .matches(contextWith(mkFactory))
+        );
+    }
+
+    @Test
+    public void shouldReturnFalseWhenConditionOnMissingComponentGivenRegistered() {
+        ComponentFactory mkFactory = Mockito.mock(ComponentFactory.class);
+        ComponentDescriptor<ConditionsTest> descriptor = new SimpleComponentDescriptor<>("any", ConditionsTest.class, () -> null, true);
+        Mockito.when(mkFactory.findAllDescriptorsByClass(Mockito.same(ConditionsTest.class))).thenReturn(List.of(descriptor));
+        Assertions.assertFalse(Conditions
+                .onMissingComponent(List.of(ConditionsTest.class))
+                .matches(contextWith(mkFactory))
+        );
+    }
+
+    @Test
+    public void shouldReturnTrueWhenConditionOnMissingComponentGivenEmpty() {
+        ComponentFactory mkFactory = Mockito.mock(ComponentFactory.class);
+        Mockito.when(mkFactory.findAllDescriptorsByClass(Mockito.same(ConditionsTest.class))).thenReturn(Collections.emptyList());
+        Assertions.assertTrue(Conditions
+                .onMissingComponent(List.of(ConditionsTest.class))
+                .matches(contextWith(mkFactory))
+        );
+    }
+
+    private ConditionContext contextWith(final ComponentFactory factory) {
+        return contextWith(null, factory);
+    }
+
+    private ConditionContext contextWith(final Conf conf) {
+        return contextWith(conf, null);
+    }
+
+    private ConditionContext contextWith(final Conf conf, final ComponentFactory factory) {
+        return new ConditionContext() {
+            @Override
+            public ComponentFactory getComponentFactory() {
+                return factory;
+            }
+
+            @Override
+            public Conf getConfig() {
+                return conf;
+            }
+
+            @Override
+            public ComponentDescriptor getComponent() {
+                return null;
+            }
+        };
+    }
+
+}

--- a/azkarra-examples/pom.xml
+++ b/azkarra-examples/pom.xml
@@ -48,7 +48,6 @@
 
     <properties>
         <checkstyle.config.location>${project.parent.basedir}</checkstyle.config.location>
-        <kafka.streams.version>2.3.0</kafka.streams.version>
         <junit.version>4.12</junit.version>
     </properties>
 

--- a/azkarra-examples/src/main/java/io/streamthoughts/examples/azkarra/conditional/ConditionalStreamsApplication.java
+++ b/azkarra-examples/src/main/java/io/streamthoughts/examples/azkarra/conditional/ConditionalStreamsApplication.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.examples.azkarra.conditional;
+
+import io.streamthoughts.azkarra.api.annotations.Component;
+import io.streamthoughts.azkarra.api.annotations.ConditionalOn;
+import io.streamthoughts.azkarra.api.annotations.Factory;
+import io.streamthoughts.azkarra.api.components.BaseComponentModule;
+import io.streamthoughts.azkarra.api.streams.TopologyProvider;
+import io.streamthoughts.azkarra.streams.AzkarraApplication;
+import io.streamthoughts.azkarra.streams.autoconfigure.annotations.AzkarraStreamsApplication;
+import io.streamthoughts.examples.azkarra.Version;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.ValueMapper;
+
+/**
+ * This example demonstrates how conditional components can be used to dynamically
+ * change the behavior of a stream topology based on its configuration.
+ */
+@AzkarraStreamsApplication
+public class ConditionalStreamsApplication {
+
+    public static void main(final String[] args) {
+        AzkarraApplication.run(ConditionalStreamsApplication.class, args);
+    }
+
+    @Component
+    @ConditionalOn(components = Normalize.class)
+    public static class NormalizeStreamsTopology extends BaseComponentModule implements TopologyProvider {
+        @Override
+        public String version() {
+            return Version.getVersion();
+        }
+        @Override
+        public Topology get() {
+            Normalize normalize = getComponent(Normalize.class);
+            final StreamsBuilder builder = new StreamsBuilder();
+            builder.stream("streams-plaintext-input", Consumed.with(Serdes.String(), Serdes.String()))
+                    .mapValues(normalize, Named.as("map" + normalize.name()))
+                    .to("streams-plaintext-upper", Produced.with(Serdes.String(), Serdes.String()));
+            return builder.build();
+        }
+    }
+
+    public interface Normalize extends ValueMapper<String, String> {
+
+        String name();
+
+        String normalize(final String s);
+
+        @Override
+        default String apply(String s) {
+            return normalize(s);
+        }
+    }
+
+    @Factory
+    public static class Normalizes {
+        @Component
+        @ConditionalOn(property = "topology.lower.enable", havingValue = "true")
+        public Normalize toLower() {
+            return new Normalize() {
+                @Override
+                public String name() {
+                    return "ToLower";
+                }
+                @Override
+                public String normalize(final String s) {
+                    return s.toLowerCase();
+                }
+            };
+        }
+
+        @Component
+        @ConditionalOn(property = "topology.upper.enable", havingValue = "true")
+        public Normalize toUpper() {
+            return new Normalize() {
+                @Override
+                public String name() {
+                    return "ToUpper";
+                }
+                @Override
+                public String normalize(final String s) {
+                    return s.toUpperCase();
+                }
+            };
+        }
+    }
+
+}

--- a/azkarra-examples/src/main/resources/application.conf
+++ b/azkarra-examples/src/main/resources/application.conf
@@ -12,6 +12,11 @@ azkarra {
     topology.topic.sink="streams-wordcount-output"
     topology.store.name="Count"
     service.stopwords=["a","an", "and", "do", "does", "it", "he", "she", "this", "that", "the" , "they", "there", "these","those","on","in"]
+
+    // Exemple : ConditionalStreamsApplication
+    // Uncomment one of the two following lines to enable the streams topologies.
+    //topology.lower.enable = true
+    //topology.upper.enable = true
   }
 
   // List of components to registered

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorBuilder.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorBuilder.java
@@ -20,6 +20,7 @@ package io.streamthoughts.azkarra.runtime.components;
 
 import io.streamthoughts.azkarra.api.components.ComponentDescriptor;
 import io.streamthoughts.azkarra.api.components.ComponentMetadata;
+import io.streamthoughts.azkarra.api.components.condition.Condition;
 import io.streamthoughts.azkarra.api.components.SimpleComponentDescriptor;
 import io.streamthoughts.azkarra.api.util.Version;
 
@@ -39,6 +40,7 @@ public class ComponentDescriptorBuilder<T> implements ComponentDescriptor<T> {
     private boolean isSingleton;
     private boolean isPrimary;
     private boolean isSecondary;
+    private Condition condition;
     private Set<String> aliases = new HashSet<>();
     private int order;
 
@@ -220,6 +222,14 @@ public class ComponentDescriptorBuilder<T> implements ComponentDescriptor<T> {
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isPrimary() {
+        return isPrimary;
+    }
+
     public ComponentDescriptorBuilder<T> isSecondary(final boolean isSecondary) {
         this.isSecondary = isSecondary;
         return this;
@@ -229,13 +239,21 @@ public class ComponentDescriptorBuilder<T> implements ComponentDescriptor<T> {
      * {@inheritDoc}
      */
     @Override
-    public boolean isPrimary() {
-        return isPrimary;
+    public boolean isSecondary() {
+        return isSecondary;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public boolean isSecondary() {
-        return false;
+    public Optional<Condition> condition() {
+        return Optional.ofNullable(condition);
+    }
+
+    public ComponentDescriptorBuilder<T> condition(final Condition condition) {
+        this.condition = condition;
+        return this;
     }
 
     /**
@@ -267,6 +285,7 @@ public class ComponentDescriptorBuilder<T> implements ComponentDescriptor<T> {
             isSingleton,
             isPrimary,
             isSecondary,
+            condition,
             order
         );
         descriptor.metadata(metadata);

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorModifiers.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorModifiers.java
@@ -20,6 +20,10 @@ package io.streamthoughts.azkarra.runtime.components;
 
 import io.streamthoughts.azkarra.api.components.ComponentDescriptor;
 import io.streamthoughts.azkarra.api.components.ComponentDescriptorModifier;
+import io.streamthoughts.azkarra.api.components.condition.Condition;
+import io.streamthoughts.azkarra.api.components.condition.Conditions;
+
+import java.util.List;
 
 public class ComponentDescriptorModifiers {
 
@@ -67,6 +71,35 @@ public class ComponentDescriptorModifiers {
             public <T> ComponentDescriptor<T> apply(final ComponentDescriptor<T> descriptor) {
                 return ComponentDescriptorBuilder.<T>create(descriptor)
                     .order(order)
+                    .build();
+            }
+        };
+    }
+
+    /**
+     * Gets a modifier implementation that will set the conditions that conditions that need to be
+     * fulfilled for the component to be eligible for use in the application.
+     *
+     * @param conditions the {@link Condition}s to add.
+     * @return           a new {@link ComponentDescriptorModifier} instance.
+     */
+    public static ComponentDescriptorModifier withConditions(final Condition... conditions) {
+        return withConditions(List.of(conditions));
+    }
+
+    /**
+     * Gets a modifier implementation that will set the conditions that conditions that need to be
+     * fulfilled for the component to be eligible for use in the application.
+     *
+     * @param conditions the {@link Condition}s to add.
+     * @return           a new {@link ComponentDescriptorModifier} instance.
+     */
+    public static ComponentDescriptorModifier withConditions(final List<Condition> conditions) {
+        return new ComponentDescriptorModifier() {
+            @Override
+            public <T> ComponentDescriptor<T> apply(final ComponentDescriptor<T> descriptor) {
+                return ComponentDescriptorBuilder.<T>create(descriptor)
+                    .condition(Conditions.compose(conditions))
                     .build();
             }
         };

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/condition/ConfigConditionalContext.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/condition/ConfigConditionalContext.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.azkarra.runtime.components.condition;
+
+import io.streamthoughts.azkarra.api.components.ComponentDescriptor;
+import io.streamthoughts.azkarra.api.components.ComponentFactory;
+import io.streamthoughts.azkarra.api.components.condition.ComponentConditionalContext;
+import io.streamthoughts.azkarra.api.components.condition.Condition;
+import io.streamthoughts.azkarra.api.components.condition.ConditionContext;
+import io.streamthoughts.azkarra.api.config.Conf;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Default {@link ComponentConditionalContext} implementation..
+ */
+public class ConfigConditionalContext<T> implements ComponentConditionalContext<ComponentDescriptor<T>> {
+
+    static <T> ConfigConditionalContext<T> of(final Conf config) {
+        return new ConfigConditionalContext<>(config);
+    }
+
+    private final Conf config;
+
+    /**
+     * Creates a new {@link ConfigConditionalContext} instance.
+     *
+     * @param config    the {@link Conf}.
+     */
+    public ConfigConditionalContext(final Conf config) {
+        this.config = Objects.requireNonNull(config);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEnable(final ComponentFactory factory,
+                            final ComponentDescriptor<T> descriptor) {
+        Objects.requireNonNull(factory, "factory must not be null");
+        Objects.requireNonNull(descriptor, "descriptor must not be null");
+
+        final Optional<Condition> optional = descriptor.condition();
+        return optional
+            .map(condition -> condition.matches(buildConditionContent(factory, descriptor)))
+            .orElse(true);
+    }
+
+    private ConditionContext<ComponentDescriptor> buildConditionContent(final ComponentFactory factory,
+                                                                        final ComponentDescriptor descriptor) {
+        return new ConditionContext<>() {
+            @Override
+            public ComponentFactory getComponentFactory() {
+                return factory;
+            }
+
+            @Override
+            public Conf getConfig() {
+                return config;
+            }
+
+            @Override
+            public ComponentDescriptor getComponent() {
+                return descriptor;
+            }
+        };
+    }
+}

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/config/AzkarraContextConfig.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/config/AzkarraContextConfig.java
@@ -20,6 +20,8 @@ package io.streamthoughts.azkarra.runtime.config;
 
 import io.streamthoughts.azkarra.api.config.Conf;
 import io.streamthoughts.azkarra.api.streams.errors.StreamThreadExceptionHandler;
+import io.streamthoughts.azkarra.runtime.interceptors.AutoCreateTopicsInterceptorConfig;
+import io.streamthoughts.azkarra.runtime.interceptors.WaitForSourceTopicsInterceptorConfig;
 import io.streamthoughts.azkarra.runtime.streams.errors.CloseKafkaStreamsOnThreadException;
 
 import java.util.Collections;
@@ -30,14 +32,49 @@ import java.util.stream.Collectors;
 
 public class AzkarraContextConfig {
 
+    /**
+     * This static field will be removed in a future version.
+     * @deprecated use {@link WaitForSourceTopicsInterceptorConfig#WAIT_FOR_TOPICS_ENABLE_CONFIG}
+     */
+    @Deprecated
     public static String WAIT_FOR_TOPICS_ENABLE_CONFIG    = "enable.wait.for.topics";
+
+    /**
+     * This static field will be removed in a future version.
+     * @deprecated use {@link AutoCreateTopicsInterceptorConfig#AUTO_CREATE_TOPICS_ENABLE_CONFIG}
+     */
+    @Deprecated
     public static String AUTO_CREATE_TOPICS_ENABLE_CONFIG = "auto.create.topics.enable";
+
+    /**
+     * This static field will be removed in a future version.
+     * @deprecated use {@link AutoCreateTopicsInterceptorConfig#AUTO_DELETE_TOPICS_ENABLE_CONFIG}
+     */
+    @Deprecated
     public static String AUTO_DELETE_TOPICS_ENABLE_CONFIG = "auto.delete.topics.enable";
+
+    /**
+     * This static field will be removed in a future version.
+     * @deprecated use {@link AutoCreateTopicsInterceptorConfig#AUTO_CREATE_TOPICS_NUM_PARTITIONS_CONFIG}
+     */
+    @Deprecated
     public static String AUTO_CREATE_TOPICS_NUM_PARTITIONS_CONFIG = "auto.create.topics.num.partitions";
+
+    /**
+     * This static field will be removed in a future version.
+     * @deprecated use {@link AutoCreateTopicsInterceptorConfig#AUTO_CREATE_TOPICS_REPLICATION_FACTOR_CONFIG}
+     */
+    @Deprecated
     public static String AUTO_CREATE_TOPICS_REPLICATION_FACTOR_CONFIG = "auto.create.topics.replication.factor";
+
+    /**
+     * This static field will be removed in a future version.
+     * @deprecated use {@link AutoCreateTopicsInterceptorConfig#AUTO_CREATE_TOPICS_CONFIGS_CONFIG}
+     */
+    @Deprecated
     public static String AUTO_CREATE_TOPICS_CONFIGS_CONFIG = "auto.create.topics.configs";
+
     public static String DEFAULT_STREAM_THREAD_EXCEPTION_HANDLER = "default.stream.thread.exception.handler";
-    public static String MONITORING_STREAMS_INTERCEPTOR_ENABLE_CONFIG = "monitoring.streams.interceptor.enable";
 
     private Conf configs;
 
@@ -56,10 +93,6 @@ public class AzkarraContextConfig {
 
     public boolean isAutoCreateTopicsEnable() {
         return configs.getOptionalBoolean(AUTO_CREATE_TOPICS_ENABLE_CONFIG).orElse(false);
-    }
-
-    public boolean isMonitoringStreamsInterceptorEnable() {
-        return configs.getOptionalBoolean(MONITORING_STREAMS_INTERCEPTOR_ENABLE_CONFIG).orElse(false);
     }
 
     public StreamThreadExceptionHandler getDefaultStreamsThreadExceptionHandler() {

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/AutoCreateTopicsInterceptorConfig.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/AutoCreateTopicsInterceptorConfig.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.runtime.interceptors;
+
+import io.streamthoughts.azkarra.api.config.Conf;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+
+/**
+ * The configuration class for {@link AutoCreateTopicsInterceptor}.
+ */
+public class AutoCreateTopicsInterceptorConfig {
+
+    /**
+     * {@code auto.create.topics.enable}
+     */
+    public static String AUTO_CREATE_TOPICS_ENABLE_CONFIG = "auto.create.topics.enable";
+
+    /**
+     * {@code auto.delete.topics.enable}
+     */
+    public static String AUTO_DELETE_TOPICS_ENABLE_CONFIG = "auto.delete.topics.enable";
+
+     /**
+      * {@code auto.create.topics.num.partitions}
+      */
+     public static String AUTO_CREATE_TOPICS_NUM_PARTITIONS_CONFIG = "auto.create.topics.num.partitions";
+     public static int AUTO_CREATE_TOPICS_NUM_PARTITIONS_DEFAULT = 1;
+
+    /**
+     * {@code auto.create.topics.replication.factor}
+     */
+    public static String AUTO_CREATE_TOPICS_REPLICATION_FACTOR_CONFIG = "auto.create.topics.replication.factor";
+    public static int AUTO_CREATE_TOPICS_REPLICATION_FACTOR_DEFAULT = 1;
+
+    /**
+     * {@code auto.create.topics.configs}
+     */
+    public static String AUTO_CREATE_TOPICS_CONFIGS_CONFIG = "auto.create.topics.configs";
+
+    private final Conf originals;
+
+    /**
+     * Creates a new {@link AutoCreateTopicsInterceptorConfig} instance.
+     *
+     * @param originals the {@link Conf} instance.
+     */
+    public AutoCreateTopicsInterceptorConfig(final Conf originals) {
+        this.originals = originals;
+    }
+
+    /**
+     * Get the default number of partitions that should be set for creating topics.
+     */
+    public int getAutoCreateTopicsNumPartition() {
+        return originals
+                .getOptionalInt(AUTO_CREATE_TOPICS_NUM_PARTITIONS_CONFIG)
+                .orElse(AUTO_CREATE_TOPICS_NUM_PARTITIONS_DEFAULT);
+    }
+
+    /**
+     * Get the default replication factor that should be should be set for creating topics.
+     */
+    public short getAutoCreateTopicsReplicationFactor() {
+        return originals
+                .getOptionalInt(AUTO_CREATE_TOPICS_REPLICATION_FACTOR_CONFIG)
+                .orElse(AUTO_CREATE_TOPICS_REPLICATION_FACTOR_DEFAULT).shortValue();
+    }
+
+    /**
+     * Get additional properties that should be should be set for creating topics.
+     */
+    public Map<String, String> getAutoCreateTopicsConfigs() {
+        if (!originals.hasPath(AUTO_CREATE_TOPICS_CONFIGS_CONFIG)) {
+            return Collections.emptyMap();
+        }
+        Properties props = originals.getSubConf(AUTO_CREATE_TOPICS_CONFIGS_CONFIG).getConfAsProperties();
+        return props.entrySet().stream().collect(
+                Collectors.toMap(
+                        e -> e.getKey().toString(),
+                        e -> e.getValue().toString()
+                )
+        );
+    }
+
+    /**
+     * Get if topics should be automatically deleted once the streams is closed.
+     */
+    public boolean isAutoDeleteTopicsEnable() {
+        return originals.getOptionalBoolean(AUTO_DELETE_TOPICS_ENABLE_CONFIG).orElse(false);
+    }
+
+    public Conf originals() {
+        return originals;
+    }
+
+}

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/MonitoringStreamsInterceptor.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/MonitoringStreamsInterceptor.java
@@ -26,7 +26,7 @@ import io.streamthoughts.azkarra.api.config.Configurable;
 import io.streamthoughts.azkarra.api.model.TimestampedValue;
 import io.streamthoughts.azkarra.api.streams.KafkaStreamsContainer;
 import io.streamthoughts.azkarra.api.streams.StateChangeEvent;
-import io.streamthoughts.azkarra.api.streams.internal.InternalStreamsLifeCycleContext;
+import io.streamthoughts.azkarra.api.streams.internal.InternalStreamsLifecycleContext;
 import io.streamthoughts.azkarra.runtime.interceptors.monitoring.KafkaStreamsMetadata;
 import io.streamthoughts.azkarra.runtime.interceptors.monitoring.MonitoringStreamsTask;
 import org.apache.kafka.clients.producer.Producer;
@@ -73,11 +73,11 @@ public class MonitoringStreamsInterceptor implements StreamsLifecycleInterceptor
     @Override
     public void onStart(final StreamsLifecycleContext context,
                         final StreamsLifecycleChain chain) {
-        LOG.info("Starting the MonitoringStreamsInterceptor for application = {}.", context.getApplicationId());
-        container = ((InternalStreamsLifeCycleContext) context).container();
+        LOG.info("Starting the MonitoringStreamsInterceptor for application = {}.", context.applicationId());
+        container = ((InternalStreamsLifecycleContext) context).container();
         container.addStateChangeWatcher(new ReporterStateChangeWatcher());
 
-        final String clientId = context.getApplicationId() + PRODUCER_CLIENT_ID_SUFFIX;
+        final String clientId = context.applicationId() + PRODUCER_CLIENT_ID_SUFFIX;
         final Map<String, Object> producerConfigs = config.getProducerConfigs(clientId);
         producer = container.getProducer(producerConfigs);
 

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/MonitoringStreamsInterceptorConfig.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/MonitoringStreamsInterceptorConfig.java
@@ -36,6 +36,9 @@ import java.util.Set;
  */
 public class MonitoringStreamsInterceptorConfig {
 
+    /** {@code monitoring.streams.interceptor.enable} */
+    public static String MONITORING_STREAMS_INTERCEPTOR_ENABLE_CONFIG = "monitoring.streams.interceptor.enable";
+
     /**
      * Prefix used to isolate {@link KafkaProducer producer} configs from other client configs.
      * It is recommended to use {@link #producerPrefix(String)} to add this prefix to {@link ProducerConfig producer

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/WaitForSourceTopicsInterceptor.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/WaitForSourceTopicsInterceptor.java
@@ -68,8 +68,8 @@ public class WaitForSourceTopicsInterceptor implements StreamsLifecycleIntercept
      */
     @Override
     public void onStart(final StreamsLifecycleContext context, final StreamsLifecycleChain chain) {
-        if (context.getState() == State.CREATED) {
-            final Set<String> sourceTopics = getSourceTopics(context.getTopology())
+        if (context.streamsState() == State.CREATED) {
+            final Set<String> sourceTopics = getSourceTopics(context.topologyDescription())
                 .stream()
                 .filter(Predicate.not(TopologyUtils::isInternalTopic))
                 .collect(Collectors.toSet());
@@ -94,7 +94,7 @@ public class WaitForSourceTopicsInterceptor implements StreamsLifecycleIntercept
     private void apply(final StreamsLifecycleContext context, final Consumer<AdminClient> consumer) {
         // use a one-shot AdminClient if no one is provided.
         if (adminClient == null) {
-            try (final AdminClient client = AdminClientUtils.newAdminClient(context.getStreamConfig())) {
+            try (final AdminClient client = AdminClientUtils.newAdminClient(context.streamsConfig())) {
                 consumer.accept(client);
             }
         } else {

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/WaitForSourceTopicsInterceptorConfig.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/WaitForSourceTopicsInterceptorConfig.java
@@ -16,18 +16,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.components;
+package io.streamthoughts.azkarra.runtime.interceptors;
 
-import io.streamthoughts.azkarra.api.errors.AzkarraException;
+/**
+ * The configuration class for {@link WaitForSourceTopicsInterceptor}.
+ */
+public class WaitForSourceTopicsInterceptorConfig {
 
-public class ConflictingBeanDefinitionException extends AzkarraException {
+    public static String WAIT_FOR_TOPICS_ENABLE_CONFIG    = "enable.wait.for.topics";
 
-    /**
-     * Creates a new {@link ConflictingBeanDefinitionException} instance.
-     *
-     * @param message   the error message.
-     */
-    public ConflictingBeanDefinitionException(final String message) {
-        super(message);
-    }
 }

--- a/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/components/condition/ConfigConditionalContextTest.java
+++ b/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/components/condition/ConfigConditionalContextTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.azkarra.runtime.components.condition;
+
+import io.streamthoughts.azkarra.api.components.ComponentDescriptor;
+import io.streamthoughts.azkarra.api.components.ComponentFactory;
+import io.streamthoughts.azkarra.api.config.Conf;
+import io.streamthoughts.azkarra.runtime.components.ComponentDescriptorBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class ConfigConditionalContextTest {
+
+    private ConfigConditionalContext<Object> context = new ConfigConditionalContext<>(Conf.empty());
+
+    @Test
+    public void shouldReturnFalseGivenNotMatchingConditionalContent() {
+        ComponentDescriptor<Object> descriptor = ComponentDescriptorBuilder
+            .create()
+            .type(Object.class)
+            .supplier(() -> null)
+            .condition(context -> false)
+            .build();
+        Assertions.assertFalse(context.isEnable(Mockito.mock(ComponentFactory.class), descriptor));
+    }
+
+    @Test
+    public void shouldReturnTrueGivenMatchingConditionalContent() {
+
+        ComponentDescriptor<Object> descriptor = ComponentDescriptorBuilder
+                .create()
+                .type(Object.class)
+                .supplier(() -> null)
+                .condition(context -> true)
+                .build();
+        Assertions.assertTrue(context.isEnable(Mockito.mock(ComponentFactory.class), descriptor));
+    }
+
+    @Test
+    public void shouldReturnTrueWhenMatchingNonConditionalComponent() {
+        ComponentDescriptor<Object> descriptor = ComponentDescriptorBuilder
+                .create()
+                .type(Object.class)
+                .supplier(() -> null)
+                .build();
+        Assertions.assertTrue(context.isEnable(Mockito.mock(ComponentFactory.class), descriptor));
+    }
+
+}

--- a/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/interceptors/AutoCreateTopicsInterceptorTest.java
+++ b/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/interceptors/AutoCreateTopicsInterceptorTest.java
@@ -21,7 +21,9 @@ package io.streamthoughts.azkarra.runtime.interceptors;
 import io.streamthoughts.azkarra.api.StreamsLifecycleChain;
 import io.streamthoughts.azkarra.api.StreamsLifecycleContext;
 import io.streamthoughts.azkarra.api.config.Conf;
+import io.streamthoughts.azkarra.api.streams.KafkaStreamsContainer;
 import io.streamthoughts.azkarra.api.streams.State;
+import io.streamthoughts.azkarra.api.util.Version;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
@@ -98,6 +100,7 @@ public class AutoCreateTopicsInterceptorTest {
         when(mkClient.deleteTopics(anyCollection())).thenReturn(mkDeleteResult);
 
         interceptor = new AutoCreateTopicsInterceptor(mkClient);
+        interceptor.configure(Conf.empty());
     }
 
     @Test
@@ -160,28 +163,43 @@ public class AutoCreateTopicsInterceptorTest {
             State state = State.CREATED;
 
             @Override
-            public String getApplicationId() {
+            public String applicationId() {
                 return "test";
             }
 
             @Override
-            public TopologyDescription getTopology() {
+            public TopologyDescription topologyDescription() {
                 return topology();
             }
 
             @Override
-            public Conf getStreamConfig() {
+            public String topologyName() {
+                return "test";
+            }
+
+            @Override
+            public Version topologyVersion() {
+                return Version.parse("1.0");
+            }
+
+            @Override
+            public Conf streamsConfig() {
                 return Conf.empty();
             }
 
             @Override
-            public State getState() {
+            public State streamsState() {
                 return state;
             }
 
             @Override
             public void setState(State state) {
                 this.state = state;
+            }
+
+            @Override
+            public void addStateChangeWatcher(KafkaStreamsContainer.StateChangeWatcher watcher) {
+
             }
         };
     }

--- a/azkarra-streams/src/main/java/io/streamthoughts/azkarra/streams/AzkarraApplication.java
+++ b/azkarra-streams/src/main/java/io/streamthoughts/azkarra/streams/AzkarraApplication.java
@@ -306,7 +306,7 @@ public class AzkarraApplication {
 
         if (autoStart.isEnable()) {
             StreamsExecutionEnvironment target = context.getEnvironmentForNameOrCreate(autoStart.targetEnvironment());
-            context.topologyProviders().forEach(desc ->
+            context.topologyProviders(target).forEach(desc ->
                 context.addTopology(
                     desc.className(),
                     desc.version().toString(),

--- a/azkarra-streams/src/main/java/io/streamthoughts/azkarra/streams/autoconfigure/AutoConfigure.java
+++ b/azkarra-streams/src/main/java/io/streamthoughts/azkarra/streams/autoconfigure/AutoConfigure.java
@@ -20,9 +20,6 @@ package io.streamthoughts.azkarra.streams.autoconfigure;
 
 import io.streamthoughts.azkarra.api.AzkarraContext;
 import io.streamthoughts.azkarra.api.util.ClassUtils;
-import io.streamthoughts.azkarra.runtime.components.ClassComponentAliasesGenerator;
-import io.streamthoughts.azkarra.runtime.components.DefaultComponentDescriptorFactory;
-import io.streamthoughts.azkarra.runtime.components.DefaultComponentFactory;
 import io.streamthoughts.azkarra.runtime.context.DefaultAzkarraContext;
 import io.streamthoughts.azkarra.streams.AzkarraApplication;
 import io.streamthoughts.azkarra.streams.autoconfigure.annotations.AzkarraStreamsApplication;
@@ -62,7 +59,7 @@ public class AutoConfigure {
 
         if (context == null) {
             LOG.info("No AzkarraContext provided, initializing default provided implementation");
-            initializeApplicationContext(application);
+            application.setContext(DefaultAzkarraContext.create());
         }
 
         final Class<?> mainApplicationClass = application.getMainApplicationClass();
@@ -79,17 +76,6 @@ public class AutoConfigure {
 
         isComponentScanEnable(mainApplicationClass)
             .ifPresent(application::setEnableComponentScan);
-    }
-
-    private void initializeApplicationContext(final AzkarraApplication application) {
-        final DefaultComponentFactory factory = new DefaultComponentFactory(
-                new DefaultComponentDescriptorFactory());
-        factory.setComponentAliasesGenerator(new ClassComponentAliasesGenerator());
-
-        // Create a default context with empty configuration
-        final AzkarraContext context = DefaultAzkarraContext.create(factory);
-
-        application.setContext(context);
     }
 
     private Optional<Boolean> isComponentScanEnable(final Class<?> source) {

--- a/azkarra-streams/src/test/java/io/streamthoughts/azkarra/streams/context/AzkarraContextLoaderTest.java
+++ b/azkarra-streams/src/test/java/io/streamthoughts/azkarra/streams/context/AzkarraContextLoaderTest.java
@@ -41,8 +41,7 @@ public class AzkarraContextLoaderTest {
 
     @BeforeEach
     public void setUp() {
-        context = create();
-        context.setComponentFactory(new DefaultComponentFactory(new DefaultComponentDescriptorFactory()));
+        context = create(new DefaultComponentFactory(new DefaultComponentDescriptorFactory()));
     }
 
     @Test

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -29,6 +29,7 @@
     <suppress checks="ClassFanOutComplexity" files="io.streamthoughts.azkarra.http.UndertowEmbeddedServer"/>
     <suppress checks="ClassFanOutComplexity" files="io.streamthoughts.azkarra.runtime.context.DefaultAzkarraContext"/>
     <suppress checks="LineLength" files="io.streamthoughts.azkarra.runtime.context.DefaultAzkarraContext"/>
+    <suppress checks="LineLength" files="io.streamthoughts.azkarra.runtime.components.DefaultComponentFactory"/>
     <suppress checks="LineLength" files="io.streamthoughts.azkarra.runtime.interceptors.MonitoringStreamsInterceptorConfig" />
     <suppress checks="LineLength" files="io.streamthoughts.azkarra.streams.components.ComponentResolver"/>
     <suppress checks="LineLength" files="io.streamthoughts.azkarra.api.streams.consumer.LogOffsetsFetcher" />


### PR DESCRIPTION
This commit allows defining the conditions that need to be fulfilled for
a component to be eligible for use in the application.

Conditions can be defined either using new annotations or ComponentDescriptorModifiers.

This commit introduce a set of new classes :

  - add new annotation classes :  ConditionalOn and Conditionals
  - add new interfaces/classes : Condition, Conditions, ConditionContext

This commit also refactor the built-in StreamsLifecycleInterceptor interface
implementations.

Breaking changes :

  - remove method AzkarraContext#setComponentFactory
  - StreamsLifecycleContext some methods have been rename
  - AutoCreateTopicsInterceptor#setConfigs renamed to setTopicConfigs
  - ConflictingBeanDefinitionException renamed to ConflictingComponentDefinitionException
  - ComponentFactory#getComponent/getAllComponents renamed to
getComponentProvider and getAllComponentProvides