### PR TITLE
feat(api): add the capability to eagerly initialize a component

### DIFF
--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/annotations/Eager.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/annotations/Eager.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.azkarra.api.annotations;
+
+/**
+ * Annotation that can be used on any class or method directly or indirectly annotated with {@link Component}.
+ * to indicate that a component is to be eagerly initialized.
+ *
+ * By default, Azkarra lazily instantiates and configures a component when it is first requested.
+ * Generally, this is the behavior desired by users because the contextual configuration of a
+ * component cannot be resolved at context startup.
+ */
+public @interface Eager {
+
+    boolean value() default true;
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentDescriptor.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentDescriptor.java
@@ -28,6 +28,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
+/**
+ * Describes a single component managed by a {@link ComponentFactory}.
+ *
+ * @param <T>   the component type.
+ */
 public interface ComponentDescriptor<T> extends Ordered {
 
     Comparator<ComponentDescriptor<?>> ORDER_BY_VERSION = (c1, c2) -> {
@@ -148,6 +153,15 @@ public interface ComponentDescriptor<T> extends Ordered {
      * @return {@code true} if is secondary, otherwise {@code false}.
      */
     boolean isSecondary();
+
+    /**
+     * Checks if the described component should be create and configure eagerly.
+     *
+     * @see io.streamthoughts.azkarra.api.annotations.Eager
+     *
+     * @return {@code true} if it s an eager component, otherwise {@code false}.
+     */
+    boolean isEager();
 
     /**
      * Gets the {@link Condition}  that need to be fulfilled for

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentFactory.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/ComponentFactory.java
@@ -220,6 +220,13 @@ public interface ComponentFactory extends
     <T> Collection<GettableComponent<T>> getAllComponentProviders(final Class<T> type,
                                                                   final Qualifier<T> qualifier);
 
+    /**
+     * Initialize the component factory for the given configuration.
+     *
+     * @param conf  the configuration.
+     */
+    void init(final Conf conf);
+
     @Override
     void close() throws IOException;
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/DelegatingComponentFactory.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/DelegatingComponentFactory.java
@@ -113,6 +113,11 @@ public class DelegatingComponentFactory implements ComponentFactory {
     }
 
     @Override
+    public void init(final Conf conf) {
+        this.factory.init(conf);
+    }
+
+    @Override
     public void close() throws IOException {
         this.factory.close();
     }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/SimpleComponentDescriptor.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/components/SimpleComponentDescriptor.java
@@ -54,6 +54,8 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
 
     private final boolean isSecondary;
 
+    private final boolean isEager;
+
     private final Condition condition;
 
     private final boolean isConditional;
@@ -79,6 +81,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
             supplier,
             null,
             isSingleton,
+            false,
             false,
             false,
             null,
@@ -109,6 +112,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
             isSingleton,
             false,
             false,
+            false,
             null,
             Ordered.LOWEST_ORDER
         );
@@ -123,6 +127,11 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
      * @param supplier      the supplier of the component.
      * @param version       the version of the component.
      * @param isSingleton   is the component singleton.
+     * @param isPrimary     is a primary component.
+     * @param isSecondary   is a secondary component.
+     * @param isEager       is the component should be eagerly initialized
+     * @param condition     is the component should be conditionally enabled.
+     * @param order         the priority of the component.
      */
     public SimpleComponentDescriptor(final String name,
                                      final Class<T> type,
@@ -132,6 +141,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
                                      final boolean isSingleton,
                                      final boolean isPrimary,
                                      final boolean isSecondary,
+                                     final boolean isEager,
                                      final Condition condition,
                                      final int order) {
         Objects.requireNonNull(type, "type can't be null");
@@ -146,6 +156,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
         this.isSingleton = isSingleton;
         this.isPrimary = isPrimary;
         this.isSecondary = isSecondary;
+        this.isEager = isEager;
         this.isConditional = condition != null;
         this.condition = condition;
         this.order = order;
@@ -165,6 +176,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
             descriptor.version().toString(),
             descriptor.isSingleton(),
             descriptor.isPrimary(),
+            descriptor.isEager(),
             descriptor.isSecondary(),
             descriptor.condition().orElse(null),
             descriptor.order()
@@ -277,6 +289,14 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
      * {@inheritDoc}
      */
     @Override
+    public boolean isEager() {
+        return isEager;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Optional<Condition> condition() {
         return Optional.ofNullable(condition);
     }
@@ -324,6 +344,7 @@ public class SimpleComponentDescriptor<T> implements ComponentDescriptor<T> {
                 ", isSingleton=" + isSingleton +
                 ", isPrimary=" + isPrimary +
                 ", isSecondary=" + isSecondary +
+                ", isEager=" + isEager +
                 ", isConditional=" + isConditional +
                 ", metadata=" + metadata +
                 ", order=" + order +

--- a/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/components/ComponentDescriptorTest.java
+++ b/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/components/ComponentDescriptorTest.java
@@ -90,6 +90,7 @@ public class ComponentDescriptorTest {
                 true,
                 false,
                 false,
+                false,
                 null,
                 order
         );
@@ -103,6 +104,7 @@ public class ComponentDescriptorTest {
             () -> null,
             version,
             true,
+            false,
             false,
             false,
             null,

--- a/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/components/condition/ConditionsTest.java
+++ b/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/components/condition/ConditionsTest.java
@@ -183,6 +183,7 @@ public class ConditionsTest {
                 true,
                 false,
                 false,
+                false,
                 condition,
                 Ordered.HIGHEST_ORDER
         );

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorBuilder.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorBuilder.java
@@ -41,6 +41,7 @@ public class ComponentDescriptorBuilder<T> implements ComponentDescriptor<T> {
     private boolean isPrimary;
     private boolean isSecondary;
     private Condition condition;
+    private boolean isEager = false;
     private Set<String> aliases = new HashSet<>();
     private int order;
 
@@ -247,6 +248,19 @@ public class ComponentDescriptorBuilder<T> implements ComponentDescriptor<T> {
      * {@inheritDoc}
      */
     @Override
+    public boolean isEager() {
+        return isEager;
+    }
+
+    public ComponentDescriptorBuilder<T> isEager(final boolean isEager) {
+        this.isEager = isEager;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Optional<Condition> condition() {
         return Optional.ofNullable(condition);
     }
@@ -285,6 +299,7 @@ public class ComponentDescriptorBuilder<T> implements ComponentDescriptor<T> {
             isSingleton,
             isPrimary,
             isSecondary,
+            isEager,
             condition,
             order
         );

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorModifiers.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/components/ComponentDescriptorModifiers.java
@@ -28,6 +28,22 @@ import java.util.List;
 public class ComponentDescriptorModifiers {
 
     /**
+     * Gets a modifier implementation that will set a component as eager.
+     *
+     * @return  a new {@link ComponentDescriptorModifier} instance.
+     */
+    public static ComponentDescriptorModifier asEager() {
+        return new ComponentDescriptorModifier() {
+            @Override
+            public <T> ComponentDescriptor<T> apply(final ComponentDescriptor<T> descriptor) {
+                return ComponentDescriptorBuilder.<T>create(descriptor)
+                        .isEager(true)
+                        .build();
+            }
+        };
+    }
+
+    /**
      * Gets a modifier implementation that will set a component as primary.
      *
      * @return  a new {@link ComponentDescriptorModifier} instance.

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/context/DefaultAzkarraContext.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/context/DefaultAzkarraContext.java
@@ -509,6 +509,7 @@ public class DefaultAzkarraContext implements AzkarraContext {
         }
         LOG.info("Starting AzkarraContext");
         preStart();
+        componentFactory.init(getConfiguration());
         try {
             listeners.forEach(listeners -> listeners.onContextStart(this));
             registerShutdownHook();


### PR DESCRIPTION
By default, Azkarra lazily instantiates and configures a component when it is first requested.
Generally, this is the behavior desired by users because the contextual configuration of a
component cannot be resolved at context startup.

This commit adds the capability for singleton components to be eagerly created
and configured at context startup.

 - add new annotation Eager
 - add new method ComponentDescriptorModifiers#asEager