### PR TITLE
feat(metrics): add built-in support for Micrometer framework

### DIFF
--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/streams/KafkaStreamsContainer.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/streams/KafkaStreamsContainer.java
@@ -606,6 +606,17 @@ public class KafkaStreamsContainer {
     }
 
     /**
+     * Returns the wrapper {@link KafkaStreams} instance.
+     *
+     * @return  the {@link KafkaStreams}.
+     */
+    public KafkaStreams getKafkaStreams() {
+        if (kafkaStreams == null)
+            throw new IllegalStateException("Cannot get access to KafkaStreams, instance is not created yet.");
+        return kafkaStreams;
+    }
+
+    /**
      * Watch a {@link KafkaStreams} instance for {@link KafkaStreams.State} change.
      *
      * By default, a {@link StateChangeWatcher} is one time called, i.e. once it is triggered,

--- a/azkarra-examples/pom.xml
+++ b/azkarra-examples/pom.xml
@@ -85,6 +85,12 @@
 
         <dependency>
             <groupId>io.streamthoughts</groupId>
+            <artifactId>azkarra-metrics</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.streamthoughts</groupId>
             <artifactId>azkarra-streams</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/azkarra-examples/src/main/resources/application.conf
+++ b/azkarra-examples/src/main/resources/application.conf
@@ -23,7 +23,8 @@ azkarra {
   components = [ ]
 
   // List of environments to registered
-  environments = [ {
+  environments = [
+    {
       name = "__default"
       config {
         enable.wait.for.topics = true
@@ -32,7 +33,18 @@ azkarra {
     }
   ]
 
+  // Uncomment to enable AzkarraMetrics
+  //metrics {
+  //  enable = false
+  //  endpoints.prometheus.enable = true
+  //  binders.jvm.enable = true
+  //  binders.kafkastreams.enable = true
+  //}
+
+  // Configuration for AzkarraServer
   server {
+    rest.extensions.enable = true
+    port = 8082
     // These information will be exposes through the http endpoint GET /info
     headless = false
     info {

--- a/azkarra-metrics/pom.xml
+++ b/azkarra-metrics/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2019 StreamThoughts.
+
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements. See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>azkarra-streams-reactor</artifactId>
+        <groupId>io.streamthoughts</groupId>
+        <version>0.7.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>azkarra-metrics</artifactId>
+
+    <properties>
+        <checkstyle.config.location>${project.parent.basedir}</checkstyle.config.location>
+        <micrometer.version>1.5.0</micrometer.version>
+    </properties>
+
+    <name>Azkarra Metrics</name>
+    <description>This project integrates Azkarra and Micrometer allowing metrics collection for Azkarra applications</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>${micrometer.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.streamthoughts</groupId>
+            <artifactId>azkarra-api</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/AzkarraMetricsConfig.java
+++ b/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/AzkarraMetricsConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.metrics;
+
+import io.streamthoughts.azkarra.api.config.Conf;
+
+import java.util.Objects;
+
+/**
+ * Properties to configure metrics.
+ */
+public class AzkarraMetricsConfig {
+
+    public static final String METRICS_ENABLE_CONFIG = "metrics.enable";
+    public static final String METRICS_BINDERS_JVM_ENABLE_CONFIG = "metrics.binders.jvm.enable";
+    public static final String METRICS_BINDERS_KAFKA_STREAMS_ENABLE_CONFIG = "metrics.binders.kafkastreams.enable";
+    public static final String METRICS_ENDPOINT_PROMETHEUS_ENABLE_CONFIG = "metrics.endpoints.prometheus.enable";
+
+    private final Conf config;
+
+    /**
+     * Creates a new {@link AzkarraMetricsConfig} instance.
+     * @param config    the {@link Conf}.
+     */
+    public AzkarraMetricsConfig(final Conf config) {
+        this.config = Objects.requireNonNull(config, "config cannot be null");
+    }
+
+    public boolean isEnable(final String name) {
+        return config.getOptionalBoolean(name).orElse(false);
+    }
+}

--- a/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/annotations/ConditionalOnMetricsEnable.java
+++ b/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/annotations/ConditionalOnMetricsEnable.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.metrics.annotations;
+
+import io.streamthoughts.azkarra.api.annotations.ConditionalOn;
+import io.streamthoughts.azkarra.metrics.AzkarraMetricsConfig;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Inherited
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ConditionalOn(property = AzkarraMetricsConfig.METRICS_ENABLE_CONFIG, havingValue = "true")
+public @interface ConditionalOnMetricsEnable {
+
+}

--- a/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/binders/JvmMeterRegistryBinderFactory.java
+++ b/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/binders/JvmMeterRegistryBinderFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.azkarra.metrics.binders;
+
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.streamthoughts.azkarra.api.annotations.Component;
+import io.streamthoughts.azkarra.api.annotations.ConditionalOn;
+import io.streamthoughts.azkarra.api.annotations.Factory;
+import io.streamthoughts.azkarra.metrics.AzkarraMetricsConfig;
+import io.streamthoughts.azkarra.metrics.annotations.ConditionalOnMetricsEnable;
+
+import javax.inject.Singleton;
+
+/**
+ * Factory to register JVM metrics binders.
+ */
+@Factory
+public class JvmMeterRegistryBinderFactory {
+
+    /**
+     * Return the JVM Memory metrics component.
+     *
+     * @return the {@link JvmGcMetrics}
+     */
+    @Component
+    @Singleton
+    @ConditionalOnMetricsEnable
+    @ConditionalOn(property = AzkarraMetricsConfig.METRICS_BINDERS_JVM_ENABLE_CONFIG, havingValue = "true")
+    @ConditionalOn(missingComponents = JvmGcMetrics.class)
+    public JvmGcMetrics jvmGcMetrics() {
+        return new JvmGcMetrics();
+    }
+
+    /**
+     * Return the JVM Memory metrics component.
+     *
+     * @return the {@link JvmMemoryMetrics}
+     */
+    @Component
+    @Singleton
+    @ConditionalOnMetricsEnable
+    @ConditionalOn(property = AzkarraMetricsConfig.METRICS_BINDERS_JVM_ENABLE_CONFIG, havingValue = "true")
+    @ConditionalOn(missingComponents = JvmMemoryMetrics.class)
+    public JvmMemoryMetrics jvmMemoryMetrics() {
+        return new JvmMemoryMetrics();
+    }
+
+    /**
+     * Return the JVM Thread metrics component.
+     *
+     * @return the {@link JvmThreadMetrics}.
+     */
+    @Component
+    @Singleton
+    @ConditionalOnMetricsEnable
+    @ConditionalOn(property = AzkarraMetricsConfig.METRICS_BINDERS_JVM_ENABLE_CONFIG, havingValue = "true")
+    @ConditionalOn(missingComponents = JvmThreadMetrics.class)
+    public JvmThreadMetrics jvmThreadMetrics() {
+        return new JvmThreadMetrics();
+    }
+
+    /**
+     * Return the JVM Class loader metrics component.
+     *
+     * @return the {@link ClassLoaderMetrics}.
+     */
+    @Component
+    @Singleton
+    @ConditionalOnMetricsEnable
+    @ConditionalOn(property = AzkarraMetricsConfig.METRICS_BINDERS_JVM_ENABLE_CONFIG, havingValue = "true")
+    @ConditionalOn(missingComponents = ClassLoaderMetrics.class)
+    public ClassLoaderMetrics classLoaderMetrics() {
+        return new ClassLoaderMetrics();
+    }
+}

--- a/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/endpoints/PrometheusEndpoint.java
+++ b/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/endpoints/PrometheusEndpoint.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.metrics.endpoints;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.streamthoughts.azkarra.api.AzkarraContext;
+import io.streamthoughts.azkarra.api.server.AzkarraRestExtension;
+import io.streamthoughts.azkarra.api.server.AzkarraRestExtensionContext;
+import io.streamthoughts.azkarra.metrics.AzkarraMetricsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Endpoint to scrap metrics in prometheus format.
+ */
+@Path("/")
+public class PrometheusEndpoint {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PrometheusEndpoint.class);
+
+    private PrometheusMeterRegistry registry;
+
+    /**
+     * Creates a new {@link PrometheusEndpoint} instance.
+     * @param registry  the {@link PrometheusMeterRegistry} instance; ust bot be {@code null}.
+     */
+    public PrometheusEndpoint(final PrometheusMeterRegistry registry) {
+        this.registry = Objects.requireNonNull(registry);
+    }
+
+    @GET
+    @Path("/prometheus")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String prometheus() {
+        return registry.scrape();
+    }
+
+    public static class PrometheusEndpointExtension implements AzkarraRestExtension {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void register(final AzkarraRestExtensionContext restContext) {
+            final AzkarraContext azkarraContext = restContext.context();
+            if (!isEndpointEnable(azkarraContext)) {
+                LOG.info("PrometheusEndpoint will not be registered to JAX-RS context. Endpoint not enabled.");
+                return;
+            }
+            PrometheusMeterRegistry registry = azkarraContext.getComponent(PrometheusMeterRegistry.class);
+            restContext.configurable().register(new PrometheusEndpoint(registry));
+        }
+
+        private boolean isEndpointEnable(final AzkarraContext context) {
+            AzkarraMetricsConfig metricsConfig = new AzkarraMetricsConfig(context.getConfiguration());
+            return metricsConfig.isEnable(AzkarraMetricsConfig.METRICS_ENABLE_CONFIG) &&
+                   metricsConfig.isEnable(AzkarraMetricsConfig.METRICS_ENDPOINT_PROMETHEUS_ENABLE_CONFIG);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void close() throws IOException {
+
+        }
+    }
+}

--- a/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/interceptor/MeterKafkaStreamsInterceptor.java
+++ b/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/interceptor/MeterKafkaStreamsInterceptor.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.metrics.interceptor;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.kafka.KafkaStreamsMetrics;
+import io.streamthoughts.azkarra.api.StreamsLifecycleChain;
+import io.streamthoughts.azkarra.api.StreamsLifecycleContext;
+import io.streamthoughts.azkarra.api.StreamsLifecycleInterceptor;
+import io.streamthoughts.azkarra.api.annotations.Component;
+import io.streamthoughts.azkarra.api.annotations.ConditionalOn;
+import io.streamthoughts.azkarra.api.components.BaseComponentModule;
+import io.streamthoughts.azkarra.api.components.qualifier.Qualifiers;
+import io.streamthoughts.azkarra.api.config.Conf;
+import io.streamthoughts.azkarra.api.streams.KafkaStreamsContainer;
+import io.streamthoughts.azkarra.api.streams.State;
+import io.streamthoughts.azkarra.api.streams.StateChangeEvent;
+import io.streamthoughts.azkarra.api.streams.internal.InternalStreamsLifecycleContext;
+import io.streamthoughts.azkarra.metrics.AzkarraMetricsConfig;
+import io.streamthoughts.azkarra.metrics.annotations.ConditionalOnMetricsEnable;
+
+import java.util.List;
+
+import static io.streamthoughts.azkarra.metrics.AzkarraMetricsConfig.METRICS_BINDERS_KAFKA_STREAMS_ENABLE_CONFIG;
+
+@Component
+@ConditionalOnMetricsEnable
+@ConditionalOn(property = METRICS_BINDERS_KAFKA_STREAMS_ENABLE_CONFIG, havingValue = "true")
+public class MeterKafkaStreamsInterceptor extends BaseComponentModule implements StreamsLifecycleInterceptor {
+
+    private static final String TAG_APPLICATION_ID = "application.id";
+
+    private KafkaStreamsMetrics metrics;
+
+    private boolean isEnable;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Conf configuration) {
+        super.configure(configuration);
+        isEnable = new AzkarraMetricsConfig(getConfiguration()).isEnable(METRICS_BINDERS_KAFKA_STREAMS_ENABLE_CONFIG);
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onStart(final StreamsLifecycleContext context,
+                        final StreamsLifecycleChain chain) {
+        if (isEnable) {
+            context.addStateChangeWatcher(new KafkaStreamsContainer.StateChangeWatcher() {
+                @Override
+                public boolean accept(final State newState) {
+                    return newState == State.RUNNING;
+                }
+
+                @Override
+                public void onChange(final StateChangeEvent event) {
+                    final List<Tag> tags = List.of(Tag.of(TAG_APPLICATION_ID, context.applicationId()));
+                    final var kafkaStreams = ((InternalStreamsLifecycleContext) context).container().getKafkaStreams();
+                    metrics = new KafkaStreamsMetrics(kafkaStreams, tags);
+                    MeterRegistry registry = getComponent(MeterRegistry.class, Qualifiers.byPrimary());
+                    metrics.bindTo(registry);
+                }
+            });
+        }
+        chain.execute();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onStop(final StreamsLifecycleContext context,
+                       final StreamsLifecycleChain chain) {
+        if (metrics != null) metrics.close();
+    }
+}

--- a/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/micrometer/MeterRegistryConfigurer.java
+++ b/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/micrometer/MeterRegistryConfigurer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.metrics.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Interfaces that is used to configure a specific type of {@link MeterRegistry}.
+ *
+ * @param <T>   the meter registry type.
+ */
+public interface MeterRegistryConfigurer<T extends MeterRegistry> {
+
+    /**
+     * Applies this configurer to the given meter registry.
+     *
+     * @param meterRegistry the {@link MeterRegistry} to configure.
+     */
+    void apply(T meterRegistry);
+
+    /**
+     * Checks whether this configurer supports the given meter registry type.
+     *
+     * @param meterRegistry a {@link MeterRegistry}.
+     * @return boolean      {@code true} if the meter registry is supported.
+     */
+    boolean supports(T meterRegistry);
+}

--- a/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/micrometer/MeterRegistryFactory.java
+++ b/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/micrometer/MeterRegistryFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.metrics.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.streamthoughts.azkarra.api.annotations.Component;
+import io.streamthoughts.azkarra.api.annotations.ConditionalOn;
+import io.streamthoughts.azkarra.api.annotations.Eager;
+import io.streamthoughts.azkarra.api.annotations.Factory;
+import io.streamthoughts.azkarra.api.annotations.Primary;
+import io.streamthoughts.azkarra.api.components.BaseComponentModule;
+import io.streamthoughts.azkarra.api.components.qualifier.Qualifiers;
+import io.streamthoughts.azkarra.metrics.annotations.ConditionalOnMetricsEnable;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.Collection;
+
+/**
+ * The default factory to build the primary {@link MeterRegistry}.
+ */
+@Factory
+public class MeterRegistryFactory extends BaseComponentModule {
+
+    private static final String COMPONENT_NAME = "AzkarraCompositeMeterRegistry";
+
+    @Eager
+    @Primary
+    @Singleton
+    @Component
+    @ConditionalOnMetricsEnable
+    @Named(MeterRegistryFactory.COMPONENT_NAME)
+    public CompositeMeterRegistry compositeMeterRegistry() {
+        final var compositeMeterRegistry = new CompositeMeterRegistry();
+        getAllComponents(MeterRegistryConfigurer.class)
+          .stream()
+          .filter(c -> c.supports(compositeMeterRegistry))
+          .forEach(c -> c.apply(compositeMeterRegistry));
+
+        Collection<MeterRegistry> registries = registries();
+        if (registries.isEmpty()) {
+            compositeMeterRegistry.add(new SimpleMeterRegistry());
+        } else {
+            registries.forEach(compositeMeterRegistry::add);
+        }
+        return compositeMeterRegistry;
+    }
+
+    @Primary
+    @Singleton
+    @Component
+    @ConditionalOnMetricsEnable
+    public MeterRegistryConfigurer meterRegistryConfigurer() {
+        Collection<MeterBinder> binders = getAllComponents(MeterBinder.class);
+        Collection<MeterFilter> filters = getAllComponents(MeterFilter.class);
+        return new MicrometerMeterRegistryConfigurer(binders, filters);
+    }
+
+    @Singleton
+    @Component
+    @ConditionalOnMetricsEnable
+    @ConditionalOn(missingComponents = PrometheusMeterRegistry.class)
+    public PrometheusMeterRegistry prometheusRegistry() {
+        return new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    }
+
+    private Collection<MeterRegistry> registries() {
+        return getAllComponents(
+            MeterRegistry.class,
+            Qualifiers.excludeByName(COMPONENT_NAME) // exclude this component from being returned
+        );
+    }
+}

--- a/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/micrometer/MicrometerMeterRegistryConfigurer.java
+++ b/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/micrometer/MicrometerMeterRegistryConfigurer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.metrics.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.config.MeterFilter;
+
+import java.util.Collection;
+
+public class MicrometerMeterRegistryConfigurer implements MeterRegistryConfigurer<MeterRegistry> {
+
+    private final Collection<MeterBinder> binders;
+    private final Collection<MeterFilter> filters;
+
+    /**
+     * Creates a new {@link MicrometerMeterRegistryConfigurer} instance.
+     *
+     * @param binders the list of {@link MeterBinder}.
+     * @param filters the list of {@link MeterFilter}.
+     */
+    public MicrometerMeterRegistryConfigurer(
+            final Collection<MeterBinder> binders,
+            final Collection<MeterFilter> filters) {
+        this.binders = binders;
+        this.filters = filters;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param meterRegistry the {@link MeterRegistry} to bind metrics to.
+     */
+    @Override
+    public void apply(final MeterRegistry meterRegistry) {
+        if (filters != null && !filters.isEmpty())
+            filters.forEach(meterRegistry.config()::meterFilter);
+
+        if (binders != null && !binders.isEmpty())
+            binders.forEach(binder -> binder.bindTo(meterRegistry));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean supports(final MeterRegistry meterRegistry) {
+        return true;
+    }
+}

--- a/azkarra-metrics/src/main/resources/META-INF/services/io.streamthoughts.azkarra.api.server.AzkarraRestExtension
+++ b/azkarra-metrics/src/main/resources/META-INF/services/io.streamthoughts.azkarra.api.server.AzkarraRestExtension
@@ -1,0 +1,1 @@
+io.streamthoughts.azkarra.metrics.endpoints.PrometheusEndpoint$PrometheusEndpointExtension

--- a/azkarra-streams/src/main/java/io/streamthoughts/azkarra/streams/context/internal/ApplicationConfig.java
+++ b/azkarra-streams/src/main/java/io/streamthoughts/azkarra/streams/context/internal/ApplicationConfig.java
@@ -61,8 +61,8 @@ public class ApplicationConfig {
      * @param environments    the environments configuration.
      */
     private ApplicationConfig(final Conf context,
-                          final Set<String> components,
-                          final List<EnvironmentConfig> environments) {
+                              final Set<String> components,
+                              final List<EnvironmentConfig> environments) {
         this.context = context;
         this.components = components;
         this.environments = environments;
@@ -97,11 +97,19 @@ public class ApplicationConfig {
 
     public static final class Reader {
 
+        private static final String AZKARRA_METRICS = "azkarra.metrics";
+
         public ApplicationConfig read(final Conf conf) {
 
             Objects.requireNonNull(conf, "conf cannot be null");
 
             Conf context = conf.hasPath(CONTEXT_CONFIG) ? conf.getSubConf(CONTEXT_CONFIG) : Conf.empty();
+            if (conf.hasPath(AZKARRA_METRICS)) {
+                // Lookup for configuration prefixed with 'metrics' to simplify the user-defined configuration.
+                // Note : this will be refactored in later version because this create a direct reference
+                // to the Azkarra Metrics module.
+                context = context.withFallback(Conf.with("metrics", conf.getSubConf(AZKARRA_METRICS)));
+            }
             return new ApplicationConfig(
                 context,
                 mayGetConfiguredComponents(conf),

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <module>azkarra-worker</module>
         <module>azkarra-examples</module>
         <module>azkarra-json-serializers</module>
+        <module>azkarra-metrics</module>
     </modules>
 
     <name>Azkarra Streams</name>


### PR DESCRIPTION
This commit is a first initiative to integrate the Micrometer framework
for allowing metrics collection for Azkarra applications

- add new maven package azkarra-metrics
- add default JAX-RS resource for exposing metrics using prometheus
- add StreamLifeCycleInterceptor for configuring micrometer binder for KafkaStreams

Resolves: #50