### PR TITLE
refactor(runtime): add InvalidStreamsEnvironmentException when enviro…

### DIFF
--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/errors/InvalidStreamsEnvironmentException.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/errors/InvalidStreamsEnvironmentException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamthoughts.azkarra.api.errors;
+
+/**
+ * The type Invalid streams environment exception.
+ */
+public class InvalidStreamsEnvironmentException extends AzkarraContextException {
+
+    /**
+     * Creates a new {@link InvalidStreamsEnvironmentException} instance.
+     *
+     * @param message the error message.
+     */
+    public InvalidStreamsEnvironmentException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new {@link InvalidStreamsEnvironmentException} instance.
+     * @param message the error message.
+     * @param cause   the exception cause.
+     */
+    public InvalidStreamsEnvironmentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/context/DefaultAzkarraContext.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/context/DefaultAzkarraContext.java
@@ -40,6 +40,7 @@ import io.streamthoughts.azkarra.api.config.Conf;
 import io.streamthoughts.azkarra.api.errors.AlreadyExistsException;
 import io.streamthoughts.azkarra.api.errors.AzkarraContextException;
 import io.streamthoughts.azkarra.api.errors.AzkarraException;
+import io.streamthoughts.azkarra.api.errors.InvalidStreamsEnvironmentException;
 import io.streamthoughts.azkarra.api.providers.TopologyDescriptor;
 import io.streamthoughts.azkarra.api.streams.ApplicationId;
 import io.streamthoughts.azkarra.api.streams.ApplicationIdBuilder;
@@ -633,7 +634,7 @@ public class DefaultAzkarraContext implements AzkarraContext {
 
     private void checkIfEnvironmentExists(final String name, final String errorMessage) {
         if (!environments.containsKey(name)) {
-            throw new AzkarraContextException(errorMessage);
+            throw new InvalidStreamsEnvironmentException(errorMessage);
         }
     }
 

--- a/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/context/DefaultAzkarraContextTest.java
+++ b/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/context/DefaultAzkarraContextTest.java
@@ -20,7 +20,7 @@ package io.streamthoughts.azkarra.runtime.context;
 
 import io.streamthoughts.azkarra.api.Executed;
 import io.streamthoughts.azkarra.api.StreamsExecutionEnvironment;
-import io.streamthoughts.azkarra.api.errors.AzkarraException;
+import io.streamthoughts.azkarra.api.errors.InvalidStreamsEnvironmentException;
 import io.streamthoughts.azkarra.api.streams.TopologyProvider;
 import io.streamthoughts.azkarra.runtime.env.DefaultStreamsExecutionEnvironment;
 import io.streamthoughts.azkarra.runtime.streams.topology.InternalExecuted;
@@ -45,7 +45,7 @@ public class DefaultAzkarraContextTest {
     @BeforeEach
     public void setUp() {
         // Create default context with empty configuration.
-        context = (DefaultAzkarraContext)DefaultAzkarraContext.create();
+        context = (DefaultAzkarraContext) DefaultAzkarraContext.create();
     }
 
     @Test
@@ -62,7 +62,7 @@ public class DefaultAzkarraContextTest {
         context.addTopology(TestTopologyProvider.class, "env", Executed.as("test"));
         context.preStart();
         Mockito.verify(env, Mockito.times(1))
-               .addTopology(Mockito.any(Supplier.class), executedArgumentCaptor.capture());
+                .addTopology(Mockito.any(Supplier.class), executedArgumentCaptor.capture());
 
         InternalExecuted executed = new InternalExecuted(executedArgumentCaptor.getValue());
         assertEquals("test", executed.name());
@@ -71,13 +71,13 @@ public class DefaultAzkarraContextTest {
     @Test
     public void shouldThrowExceptionWhenAddingTopologyGivenUnknownEnvironment() {
         context.addTopology(TestTopologyProvider.class, "env", Executed.as("test"));
-        AzkarraException exception = Assertions.assertThrows(AzkarraException.class, () -> {
+        InvalidStreamsEnvironmentException exception = Assertions.assertThrows(InvalidStreamsEnvironmentException.class, () -> {
             context.start();
         });
 
         String errorMessage = exception.getMessage();
         assertEquals("Error while adding topology '"
-            + TestTopologyProvider.class.getName() + "', environment 'env' not found", errorMessage);
+                + TestTopologyProvider.class.getName() + "', environment 'env' not found", errorMessage);
     }
 
 


### PR DESCRIPTION
…nment not found

This commit updates the existing exception to InvalidStreamsEnvironmentException if enviroment is unknown

- add new InvalidStreamsEnvironmentException
- update checkIfEnvironmentExists of DefaultAzkarraContext method to throw InvalidStreamsEnvironmentException
- update test accordinngly

Resolves: #60