### PR TITLE
feat(api/server): add support for HTTP Server-Sent Event (#100)

### DIFF
--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/BasicBlockingRecordQueue.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/BasicBlockingRecordQueue.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events;
+
+import io.streamthoughts.azkarra.api.events.callback.LimitQueueCallback;
+import io.streamthoughts.azkarra.api.events.callback.LimitedQueueCallback;
+import io.streamthoughts.azkarra.api.events.callback.QueueCallback;
+import io.streamthoughts.azkarra.api.model.KV;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A simple {@link BlockingRecordQueue} backed by a {@link BlockingQueue}.
+ *
+ * @param <K>     the record-key type.
+ * @param <V>     the record-value type.
+ *
+ * @since 0.8.0
+ */
+public class BasicBlockingRecordQueue<K, V> implements BlockingRecordQueue<K, V> {
+
+    private static final int DEFAULT_QUEUE_SIZE_LIMIT = 10_000;
+
+    private final BlockingQueue<KV<K, V>> blockingQueue;
+
+    private final Duration offerWaitDuration;
+
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+
+    private LimitQueueCallback callback;
+
+    /**
+     * Creates a new {@link BasicBlockingRecordQueue} instance.
+     */
+    public BasicBlockingRecordQueue() {
+        this(DEFAULT_QUEUE_SIZE_LIMIT);
+    }
+
+    /**
+     * Creates a new {@link BasicBlockingRecordQueue} instance.
+     *
+     * @param queueSizeLimit    the queue max capacity.
+     */
+    public BasicBlockingRecordQueue(final int queueSizeLimit) {
+        this(queueSizeLimit, Duration.ofMillis(100), LimitHandlers.NO_OP);
+    }
+
+    /**
+     *
+     * @param queueSizeLimit    the blocking size limit;
+     * @param offerWaitDuration the time to wait if necessary for space to become available.
+     */
+    private BasicBlockingRecordQueue(final int queueSizeLimit,
+                                     final Duration offerWaitDuration,
+                                     final LimitHandler limitHandler) {
+        if (queueSizeLimit <= 0)
+            throw new IllegalArgumentException("queueSizeLimit must be superior to 0, was :" + queueSizeLimit);
+
+        this.blockingQueue = new LinkedBlockingQueue<>(queueSizeLimit);
+        this.offerWaitDuration = offerWaitDuration;
+        this.callback = new LimitedQueueCallback(queueSizeLimit);
+        this.callback.setQueue(this);
+        this.callback.setLimitHandler(limitHandler);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setLimitHandler(final LimitHandler limitHandler) {
+        Objects.requireNonNull(limitHandler, "limitHandler cannot be null");
+        this.callback.setLimitHandler(limitHandler);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setQueueCallback(final QueueCallback callback) {
+        Objects.requireNonNull(callback, "callback cannot be null");
+        var parent = this.callback;
+        this.callback = new LimitQueueCallback() {
+            @Override
+            public void setLimitHandler(final LimitHandler limitHandler) {
+                parent.setLimitHandler(limitHandler);
+            }
+
+            @Override
+            public void setQueue(final BlockingRecordQueue queue) {
+                parent.setQueue(queue);
+            }
+
+            @Override
+            public void onQueued() {
+                callback.onQueued();
+                parent.onQueued();
+            }
+
+            @Override
+            public void onClosed() {
+                callback.onClosed();
+                parent.onClosed();
+            }
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KV<K, V> poll(final Duration timeout) throws InterruptedException {
+        return blockingQueue.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KV<K, V> poll() {
+        return blockingQueue.poll();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void drainTo(final Collection<? super KV<K, V>> collection) {
+        blockingQueue.drainTo(collection);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int size() {
+        return blockingQueue.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEmpty() {
+        return blockingQueue.isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void open() {
+        isClosed.set(false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        isClosed.set(true);
+        if (callback != null) callback.onClosed();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void send(final KV<K, V> record) {
+        if (record == null)
+            return;
+
+        try {
+            while (!isClosed.get()) {
+                if (blockingQueue.offer(record, offerWaitDuration.toMillis(), TimeUnit.MILLISECONDS)) {
+                    if (callback != null) callback.onQueued();
+                    break;
+                }
+            }
+        } catch (final InterruptedException ignore) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clear() {
+        this.blockingQueue.clear();
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/BlockingRecordQueue.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/BlockingRecordQueue.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events;
+
+import io.streamthoughts.azkarra.api.events.callback.QueueCallback;
+import io.streamthoughts.azkarra.api.model.KV;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A blocking queue that can be used for publishing key-value records from a Kafka Streams topology.
+ *
+ * @param <K> the record-key type
+ * @param <V> the record-value type
+ *
+ * @since 0.8.0
+ */
+public interface BlockingRecordQueue<K, V> {
+
+    /**
+     * Sets the handler to be invoked when the limit queue is reached.
+     *
+     * @param handler   the {@link LimitHandler} instance.
+     */
+    void setLimitHandler(final LimitHandler handler);
+
+    /**
+     * Sets the callback to be executed when a new record is queued or the queue is closed.
+     *
+     * @param callback  the {@link QueueCallback} to execute.
+     */
+    void setQueueCallback(final QueueCallback callback);
+
+    /**
+     * @see BlockingQueue#poll(long, TimeUnit)
+     */
+    KV<K, V> poll(final Duration timeout) throws InterruptedException;
+
+    /**
+     * @see BlockingQueue#poll()
+     */
+    KV<K, V> poll();
+
+    /**
+     * @see BlockingQueue#drainTo(Collection)
+     */
+    void drainTo(final Collection<? super KV<K, V>> collection);
+
+    /**
+     * @return  the number of records queued.
+     */
+    int size();
+
+    /**
+     *
+     * @return {@code true} if the queue is empty.
+     */
+    boolean isEmpty();
+
+    /**
+     * Open the queue.
+     */
+    void open();
+
+    /**
+     * Close the queue. The records sent after the queue is closed will be ignored.
+     */
+    void close();
+
+    /**
+     * Sends a key-value record into this queue.
+     *
+     * @param kv    the {@link KV} record.
+     */
+    void send(final KV<K, V> kv);
+
+    /**
+     * @see BlockingQueue#clear()
+     */
+    void clear();
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/DelegateBlockingRecordQueue.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/DelegateBlockingRecordQueue.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events;
+
+import io.streamthoughts.azkarra.api.events.callback.QueueCallback;
+import io.streamthoughts.azkarra.api.model.KV;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ *  A delegating {@link BlockingRecordQueue} that can be used to easily override some methods.
+ *
+ * @param <K>   the record-key type.
+ * @param <V>   the record-value type.
+ */
+public class DelegateBlockingRecordQueue<K, V> implements BlockingRecordQueue<K, V> {
+
+    private final BlockingRecordQueue<K, V> delegate;
+
+    protected DelegateBlockingRecordQueue(final BlockingRecordQueue<K, V> delegate) {
+        this.delegate = Objects.requireNonNull(delegate, "delegating queue cannot be null");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setLimitHandler(final LimitHandler handler) {
+        delegate.setLimitHandler(handler);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setQueueCallback(final QueueCallback callback) {
+        delegate.setQueueCallback(callback);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KV<K, V> poll(final Duration timeout) throws InterruptedException {
+        return delegate.poll(timeout);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KV<K, V> poll() {
+        return delegate.poll();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void drainTo(final Collection<? super KV<K, V>> collection) {
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void open() {
+        delegate.open();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void send(KV<K, V> record) {
+        delegate.send(record);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/EventStream.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/EventStream.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events;
+
+import io.streamthoughts.azkarra.api.model.KV;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A typed stream of events backed by a {@link BlockingRecordQueue}.
+ *
+ * @param <K>   the record key type.
+ * @param <V>   the record value type.
+ *
+ * @since 0.8.0
+ */
+public class EventStream<K, V> {
+
+    private final String type;
+    private final BlockingRecordQueue<K, V> queue;
+
+    private final AtomicBoolean opened = new AtomicBoolean(false);
+
+    public static class Builder {
+
+        private String eventType;
+        private Integer queueSize;
+        private LimitHandler queueLimitHandler;
+
+        /**
+         * Creates a new {@link Builder} instance.
+         *
+         * @param eventType the event-type.
+         */
+        public Builder(final String eventType) {
+            this.eventType = eventType;
+        }
+
+        public Builder withQueueSize(final int queueSize) {
+            this.queueSize = queueSize;
+            return this;
+        }
+
+        public Builder withQueueLimitHandler(final LimitHandler queueLimitHandler) {
+            this.queueLimitHandler = queueLimitHandler;
+            return this;
+        }
+
+        public <K, V> EventStream<K, V> build() {
+            var queue = queueSize != null ?
+                new BasicBlockingRecordQueue<K, V>(queueSize) :
+                new BasicBlockingRecordQueue<K, V>();
+
+            if (queueLimitHandler != null)
+                queue.setLimitHandler(queueLimitHandler);
+            return new EventStream<>(eventType, queue);
+        }
+    }
+
+    /**
+     * Creates a new {@link EventStream} instance.
+     *
+     * @param type  the name of the events send to this stream.
+     * @param queue the {@link BlockingRecordQueue}.
+     */
+    public EventStream(final String type, final BlockingRecordQueue<K, V> queue) {
+        this.type = Objects.requireNonNull(type, "eventType cannot be null");
+        this.queue = Objects.requireNonNull(queue, "queue cannot be null");
+    }
+
+    /**
+     * @return  the name of the events send to this stream.
+     */
+    public String type() {
+        return type;
+    }
+
+    public synchronized void open(final EventStreamPipe<K, V> pipe) {
+        Objects.requireNonNull(pipe, "pipe cannot be null");
+        if (opened.get()) {
+           throw new IllegalStateException("This stream is already open");
+        }
+        pipe.onOpen(queue);
+        queue.open();
+    }
+
+    public synchronized void close() {
+        try {
+            queue.close();
+            queue.clear();
+        } finally {
+            opened.set(false);
+        }
+    }
+
+    /**
+     * Sends a key-value record into this queue.
+     *
+     * @param value    the record value.
+     */
+    public void send(final V value) {
+        send(KV.of(null, value));
+    }
+
+    /**
+     * Sends a key-value record into this stream.
+     *
+     * @param key      the record key.
+     * @param value    the record value.
+     */
+    public void send(final K key, final V value) {
+        send(KV.of(key, value));
+    }
+
+    /**
+     * Sends a timestamped key-value record into this stream.
+     *
+     * @param key      the record key.
+     * @param value    the record value.
+     */
+    public void send(final K key, final V value, final long timestamp) {
+        send(KV.of(key, value, timestamp));
+    }
+
+    /**
+     * Sends a null-key value record into this stream.
+     *
+     * @param kv    the {@link KV} record.
+     */
+    public void send(final KV<K, V> kv) {
+        queue.send(kv);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "EventStream{" + "type='" + type + "\"}";
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/EventStreamPipe.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/EventStreamPipe.java
@@ -16,38 +16,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.streams.topology;
+package io.streamthoughts.azkarra.api.events;
 
-import io.streamthoughts.azkarra.api.events.EventStream;
-import org.apache.kafka.streams.Topology;
-
-import java.util.Collections;
-import java.util.List;
-
-public interface TopologyDefinition {
-
-    /**
-     * @return  the topology name.
-     */
-    String getName();
-
-    /**
-     * @return  the topology version.
-     */
-    String getVersion();
+/**
+ * The EventStreamPipe is used to attached or detach an object that will be responsible to consume
+ * records send to an {@link EventStream}.
+ *
+ * @see EventStream#open(EventStreamPipe)
+ *
+ * @param <K>   the record-key type.
+ * @param <V>   the record-value type.
+ *
+ * @since 0.8.0
+ */
+public interface EventStreamPipe<K, V> {
 
     /**
-     * @return the topology description.
+     * Set the queue from which records are produced.
+     *
+     * @param queue the {@link BlockingRecordQueue}.
      */
-    String getDescription();
-
-    /**
-     * @return the {@link Topology}.
-     */
-    Topology getTopology();
-
-    default List<EventStream> getEventStreams() {
-        return Collections.emptyList();
-    }
+    void onOpen(final BlockingRecordQueue<K, V> queue);
 
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/EventStreamProvider.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/EventStreamProvider.java
@@ -16,38 +16,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.streams.topology;
+package io.streamthoughts.azkarra.api.events;
 
-import io.streamthoughts.azkarra.api.events.EventStream;
-import org.apache.kafka.streams.Topology;
-
-import java.util.Collections;
 import java.util.List;
 
-public interface TopologyDefinition {
+/**
+ * EventStreamsProvider.
+ *
+ * @since 0.8.0
+ */
+public interface EventStreamProvider {
 
     /**
-     * @return  the topology name.
+     * Returns the list of {@link EventStream}
+     *
+     * @return  a list of {@link EventStream}. Must not return {@code null}.
      */
-    String getName();
-
-    /**
-     * @return  the topology version.
-     */
-    String getVersion();
-
-    /**
-     * @return the topology description.
-     */
-    String getDescription();
-
-    /**
-     * @return the {@link Topology}.
-     */
-    Topology getTopology();
-
-    default List<EventStream> getEventStreams() {
-        return Collections.emptyList();
-    }
+    List<EventStream> getEventStreams();
 
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/EventStreamSupport.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/EventStreamSupport.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events;
+
+import io.streamthoughts.azkarra.api.errors.AzkarraException;
+import io.streamthoughts.azkarra.api.model.KV;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Base class for {@link EventStreamProvider}.
+ * This class provides convenient methods to register {@link EventStream} and to send records.
+ *
+ * @since 0.8.0
+ */
+public class EventStreamSupport implements EventStreamProvider {
+
+    private final Map<String, EventStream<?, ?>> streams = new HashMap<>();
+
+    private LimitHandler defaultLimitHandler;
+
+    private int defaultQueueSize;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<EventStream> getEventStreams() {
+        return new ArrayList<>(streams.values());
+    }
+
+    public <K, V> void addEventStream(final EventStream<K, V> eventStream) {
+        if (streams.put(eventStream.type(), eventStream) != null) {
+            throw new IllegalArgumentException("EventStream already registered for type: " + eventStream.type());
+        }
+    }
+
+    protected void addEventStreamsWithDefaults(final String... types) {
+        for (final String type : types) {
+            addEventStream(new EventStream.Builder(type)
+                .withQueueSize(defaultQueueSize)
+                .withQueueLimitHandler(defaultLimitHandler)
+                .build()
+            );
+        }
+    }
+
+    /**
+     * Sets the default {@link LimitHandler} that will be used for creating {@link EventStream}.
+     *
+     * @param limitHandler  the {@link LimitHandler}.
+     */
+    protected void setDefaultEventQueueLimitHandler(final LimitHandler limitHandler) {
+        defaultLimitHandler = Objects.requireNonNull(limitHandler, "limitHandler cannot be null");
+    }
+
+    /**
+     * Sets the default event queue size that will be used for creating {@link EventStream}.
+     *
+     * @param queueSize  the queue size.
+     */
+    protected void setDefaultEventQueueSize(final int queueSize) {
+        defaultQueueSize = queueSize;
+    }
+
+    /**
+     * Sends a key-value record into this queue.
+     *
+     * @param type  the type of the event-stream.
+     * @param value the record value.
+     */
+    public <K, V>  void send(final String type, final V value) {
+        getEventStreamOrThrow(type).send(KV.of(null, value));
+    }
+
+    /**
+     * Sends a key-value record into the given stream.
+     *
+     * @param type  the type of the event-stream.
+     * @param key   the record key.
+     * @param value the record value.
+     */
+    public <K, V> void send(final String type, final K key, final V value) {
+        getEventStreamOrThrow(type).send(KV.of(key, value));
+    }
+
+    /**
+     * Sends a timestamped key-value record into the given stream.
+     *
+     * @param type  the type of the event-stream.
+     * @param key   the record key.
+     * @param value the record value.
+     */
+    public <K, V>  void send(final String type, final K key, final V value, final long timestamp) {
+        getEventStreamOrThrow(type).send(KV.of(key, value, timestamp));
+    }
+
+    /**
+     * Sends a null-key value record into into the given stream.
+     *
+     * @param type  the type of the event-stream.
+     * @param kv    the {@link KV} record.
+     */
+    public <K, V>  void send(final String type, final KV<K, V> kv) {
+        getEventStreamOrThrow(type).send(kv);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <K, V> EventStream<K, V> getEventStreamOrThrow(final String type) {
+        EventStream<?, ?> es = streams.get(type);
+        if (es == null) {
+            throw new AzkarraException("No EventStream registered for type: " + type);
+        }
+        return (EventStream<K, V>)es;
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/LimitHandler.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/LimitHandler.java
@@ -16,38 +16,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.streams.topology;
+package io.streamthoughts.azkarra.api.events;
 
-import io.streamthoughts.azkarra.api.events.EventStream;
-import org.apache.kafka.streams.Topology;
+import io.streamthoughts.azkarra.api.errors.AzkarraException;
 
-import java.util.Collections;
-import java.util.List;
+/**
+ * The default interface to be used for executing logic when buffer limit is reached.
+ *
+ * @see BlockingRecordQueue
+ *
+ * @since 0.8.0
+ */
+@FunctionalInterface
+public interface LimitHandler {
 
-public interface TopologyDefinition {
-
-    /**
-     * @return  the topology name.
-     */
-    String getName();
-
-    /**
-     * @return  the topology version.
-     */
-    String getVersion();
-
-    /**
-     * @return the topology description.
-     */
-    String getDescription();
-
-    /**
-     * @return the {@link Topology}.
-     */
-    Topology getTopology();
-
-    default List<EventStream> getEventStreams() {
-        return Collections.emptyList();
+    class BlockingQueueLimitReachedException extends AzkarraException {
+        BlockingQueueLimitReachedException(final String message) {
+            super(message);
+        }
     }
 
+    /**
+     * Invokes when the limit of a {@link BlockingRecordQueue} is reached.
+     *
+     * @param queue the queue that reached its limit.
+     */
+    <K, V> void onLimitReached(final BlockingRecordQueue<K, V> queue);
 }
+
+

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/LimitHandlers.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/LimitHandlers.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.streamthoughts.azkarra.api.events.LimitHandler.BlockingQueueLimitReachedException;
+
+/**
+ * Provides built-in {@link LimitHandler} implementation.
+ *
+ * @since 0.8.0
+ */
+public class LimitHandlers {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DropHeadOnLimitReached.class);
+
+    public static final LimitHandler NO_OP = new LimitHandler() {
+        @Override
+        public <K, V> void onLimitReached(final BlockingRecordQueue<K, V> queue) { }
+    };
+
+    /**
+     * @return a new {@link LimitHandler} that log anc continue when queue limit is reached.
+     */
+    public static LimitHandler logAndContinueOnLimitReached() {
+        return new LogAndContinueOnLimitReached();
+    }
+
+    /**
+     * @return a new {@link LimitHandler} that throws a {@link BlockingQueueLimitReachedException}
+     * when queue limit is reached.
+     */
+    public static LimitHandler throwExceptionOnLimitReached() {
+        return new FailOnLimitReached();
+    }
+
+    /**
+     * @return a new {@link LimitHandler} that retrieves and drop the head of the when queue limit is reached.
+     */
+    public static LimitHandler dropHeadOnLimitReached() {
+        return new FailOnLimitReached();
+    }
+
+    private static final class LogAndContinueOnLimitReached implements LimitHandler {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <K, V> void onLimitReached(final BlockingRecordQueue<K, V> queue) {
+            LOG.warn("Blocking queue limit reached. Ignore and continue");
+        }
+    }
+
+    private static final class DropHeadOnLimitReached implements LimitHandler {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <K, V> void onLimitReached(final BlockingRecordQueue<K, V> queue) {
+            LOG.warn("Blocking queue limit reached. Dropping head record");
+            queue.poll();
+        }
+    }
+
+
+    private static final class FailOnLimitReached implements LimitHandler {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public <K, V> void onLimitReached(final BlockingRecordQueue<K, V> queue) {
+            throw new BlockingQueueLimitReachedException("Blocking queue limit reached");
+        }
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/callback/LimitQueueCallback.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/callback/LimitQueueCallback.java
@@ -16,38 +16,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.streams.topology;
+package io.streamthoughts.azkarra.api.events.callback;
 
-import io.streamthoughts.azkarra.api.events.EventStream;
-import org.apache.kafka.streams.Topology;
+import io.streamthoughts.azkarra.api.events.BlockingRecordQueue;
+import io.streamthoughts.azkarra.api.events.LimitHandler;
 
-import java.util.Collections;
-import java.util.List;
-
-public interface TopologyDefinition {
-
-    /**
-     * @return  the topology name.
-     */
-    String getName();
+/**
+ * The limit callback for {@link BlockingRecordQueue}.
+ *
+ * @since 0.8.0
+ */
+public interface LimitQueueCallback extends QueueCallback {
 
     /**
-     * @return  the topology version.
+     * Sets the handler to be invoked when the queue limit is reached.
+     *
+     * @param limitHandler  the {@link LimitHandler}.
      */
-    String getVersion();
+    void setLimitHandler(final LimitHandler limitHandler);
 
     /**
-     * @return the topology description.
+     * Sets the {@link BlockingRecordQueue} to be passed to the {@link LimitHandler}.
+     *
+     * @param queue the {@link BlockingRecordQueue}.
      */
-    String getDescription();
-
-    /**
-     * @return the {@link Topology}.
-     */
-    Topology getTopology();
-
-    default List<EventStream> getEventStreams() {
-        return Collections.emptyList();
-    }
-
+    void setQueue(final BlockingRecordQueue queue);
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/callback/LimitedQueueCallback.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/callback/LimitedQueueCallback.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events.callback;
+
+import io.streamthoughts.azkarra.api.events.BlockingRecordQueue;
+import io.streamthoughts.azkarra.api.events.LimitHandler;
+import io.streamthoughts.azkarra.api.events.LimitHandlers;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The default {@link LimitQueueCallback} implementation.
+ *
+ * @since 0.8.0
+ */
+public class LimitedQueueCallback implements LimitQueueCallback {
+
+    private final AtomicInteger remaining;
+    private volatile LimitHandler limitHandler = LimitHandlers.NO_OP;
+    private volatile BlockingRecordQueue<?, ?> queue;
+    private final int limit;
+
+    /**
+     * Creates a new {@link LimitedQueueCallback} instance.
+     *
+     * @param limit  the queue limit.
+     */
+    public LimitedQueueCallback(final int limit) {
+        if (limit < 0) throw new IllegalArgumentException("limit must be positive, given: " + limit);
+        this.limit = limit;
+        this.remaining = new AtomicInteger(limit);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setLimitHandler(final LimitHandler limitHandler) {
+        this.limitHandler = Objects.requireNonNull(limitHandler, "limitHandler");
+        if (remaining.get() == 0) {
+            limitHandler.onLimitReached(queue);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setQueue(final BlockingRecordQueue queue) {
+        this.queue = queue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onQueued() {
+        if (remaining.decrementAndGet() == 0) {
+            limitHandler.onLimitReached(queue);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onClosed() {
+        // reset callback.
+        this.remaining.set(limit);
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/callback/QueueCallback.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/callback/QueueCallback.java
@@ -16,38 +16,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.streams.topology;
+package io.streamthoughts.azkarra.api.events.callback;
 
-import io.streamthoughts.azkarra.api.events.EventStream;
-import org.apache.kafka.streams.Topology;
+import io.streamthoughts.azkarra.api.events.BlockingRecordQueue;
 
-import java.util.Collections;
-import java.util.List;
-
-public interface TopologyDefinition {
-
-    /**
-     * @return  the topology name.
-     */
-    String getName();
+/**
+ * The callback for {@link BlockingRecordQueue}.
+ *
+ * @since 0.8.0
+ */
+public interface QueueCallback {
 
     /**
-     * @return  the topology version.
+     * Invokes when the queue is closed.
      */
-    String getVersion();
+    void onClosed();
 
     /**
-     * @return the topology description.
+     * Invokes when a new record is queued.
      */
-    String getDescription();
-
-    /**
-     * @return the {@link Topology}.
-     */
-    Topology getTopology();
-
-    default List<EventStream> getEventStreams() {
-        return Collections.emptyList();
-    }
+    void onQueued();
 
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/AsyncMulticastEventStreamPublisher.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/AsyncMulticastEventStreamPublisher.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events.reactive;
+
+import io.streamthoughts.azkarra.api.events.BlockingRecordQueue;
+import io.streamthoughts.azkarra.api.events.EventStream;
+import io.streamthoughts.azkarra.api.events.callback.QueueCallback;
+import io.streamthoughts.azkarra.api.events.reactive.internal.SequentialSubscriptionIdGenerator;
+import io.streamthoughts.azkarra.api.events.reactive.internal.SubscriptionId;
+import io.streamthoughts.azkarra.api.events.reactive.internal.SubscriptionIdGenerator;
+import io.streamthoughts.azkarra.api.model.KV;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The AsyncMulticastEventStreamPublisher is an implementation of Reactive Streams {@link Flow.Publisher}
+ * which executes asynchronously, using an internal single-thread {@link java.util.concurrent.Executor}.
+ *
+ * Records are produced from a given {@link EventStream} in a "multicast" configuration to its {@link Flow.Subscriber}.
+ *
+ * Note: A subscriber will start receiving events from the head of the event-stream buffer,
+ * as soon as it perform a valid request demand. The publisher will continue to poll the event-stream buffer as long
+ * as at-least one subscriber is requesting more records, i.e even if other subscriptions are applying back-pressure.
+ *
+ * @since 0.8.0
+ */
+public class AsyncMulticastEventStreamPublisher<K, V> implements EventStreamPublisher<K, V> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AsyncMulticastEventStreamPublisher.class);
+
+    // The maximum number of records to try to poll from the queue on each send.
+    private static final int MAX_POLL_RECORDS = 100;
+    private static final Duration AWAIT_TERMINATION_TIMEOUT = Duration.ofSeconds(30);
+
+    private final EventStream<K, V> stream;
+    private final SubscriptionIdGenerator idGenerator;
+
+    private final EventLoop eventLoop = new EventLoop();
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private BlockingRecordQueue<K, V> queue;
+
+    private final ConcurrentHashMap<SubscriptionId, EventStreamSubscription<KV<K, V>>> subscriptions
+            = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a new {@link AsyncMulticastEventStreamPublisher} instance.
+     *
+     * @param stream   the {@link EventStream}.
+     */
+    public AsyncMulticastEventStreamPublisher(final EventStream<K, V> stream) {
+        this(stream, new SequentialSubscriptionIdGenerator());
+    }
+
+    /**
+     * Creates a new {@link AsyncMulticastEventStreamPublisher} instance.
+     *
+     * @param stream   the {@link EventStream}.
+     */
+    private AsyncMulticastEventStreamPublisher(final EventStream<K, V> stream,
+                                               final SubscriptionIdGenerator subscriptionIdGenerator) {
+        this.stream = requireNonNull(stream, "stream cannot be null");
+        this.idGenerator = requireNonNull(subscriptionIdGenerator, "subscriptionIdGenerator cannot be null");
+        init();
+    }
+
+    private void init() {
+        stream.open(queue -> {
+            AsyncMulticastEventStreamPublisher.this.queue = queue;
+            queue.setQueueCallback(new QueueCallback() {
+                @Override
+                public void onClosed() {
+                    closed.set(true);
+                    eventLoop.signal(Complete.Instance);
+                    eventLoop.awaitTerminationAndDoComplete(AWAIT_TERMINATION_TIMEOUT);
+                }
+
+                @Override
+                public void onQueued() {
+                    eventLoop.signal(Send.Instance);
+                }
+            });
+        });
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String type() {
+        return stream.type();
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void subscribe(final Flow.Subscriber<? super KV<K, V>> subscriber) {
+        // throw NullPointerException if an illegal parameter is passed (rule 2.13)
+        Objects.requireNonNull(subscriber, "subscriber cannot be null");
+
+        if (closed.get()) {
+            // make sure we signal onSubscribe before onComplete,
+            // because the publisher is already closed we do not have anything to send
+            subscriber.onSubscribe(new Flow.Subscription() {
+                @Override public void cancel() {}
+                @Override public void request(long n) {}
+            });
+            subscriber.onComplete();
+            return;
+        }
+
+        new InternalEventStreamSubscription(subscriber, idGenerator.generateNext()).init();
+    }
+
+    private boolean hasMoreRecords() {
+        return !queue.isEmpty();
+    }
+
+    private boolean hasActiveSubscriptions() {
+        return subscriptions.values()
+            .stream()
+            .anyMatch(EventStreamSubscription::canReceived);
+    }
+
+    private Collection<EventStreamSubscription<KV<K, V>>> subscriptions() {
+        return subscriptions.values();
+    }
+
+    // The MulticastEventStreamPublisher protocol
+    interface Signal { }
+    enum Send implements Signal { Instance } // Multi-cast
+    enum Complete implements Signal { Instance } // Multi-cast
+    static abstract class SubscriptionSignal implements Signal {
+        final EventStreamSubscription subscription;
+
+        SubscriptionSignal(final EventStreamSubscription subscription) {
+            this.subscription = Objects.requireNonNull(subscription, "subscription cannot be null");
+        }
+
+        public abstract void execute();
+    }
+    static final class Request<K, V> extends SubscriptionSignal {
+        final long demands;
+
+        Request(final EventStreamSubscription<KV<K, V>> subscription, final long demands) {
+            super(subscription);
+            this.demands = demands;
+        }
+
+        @Override
+        public void execute() {
+            subscription.doOnRequest(demands);
+        }
+    }
+
+    static final class Cancel<K, V> extends SubscriptionSignal {
+        Cancel(final EventStreamSubscription<KV<K, V>> subscription) {
+            super(subscription);
+        }
+
+        @Override
+        public void execute() {
+            subscription.doOnCancel();
+        }
+    }
+
+    static final class Subscribe<K, V> extends SubscriptionSignal {
+        Subscribe(final EventStreamSubscription<KV<K, V>> subscription) {
+            super(subscription);
+        }
+
+        @Override
+        public void execute() {
+            subscription.doOnSubscribe();
+        }
+    }
+
+    /**
+     * The main event-loop that processes {@link Signal}.
+     */
+    private class EventLoop implements Runnable {
+
+        private final ConcurrentLinkedQueue<Signal> inboundSignals = new ConcurrentLinkedQueue<>();
+
+        private ExecutorService executor;
+
+        private final AtomicBoolean on = new AtomicBoolean(false);
+
+        /**
+         * Creates a new {@link EventLoop}.
+         */
+        EventLoop() {
+            executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "event-streams-loop-publisher"));
+        }
+
+        public void signal(final Signal signal) {
+            if (inboundSignals.offer(signal))
+                tryScheduleToExecute();
+        }
+
+        private void tryScheduleToExecute() {
+            if(on.compareAndSet(false, true)) {
+                try {
+                    executor.execute(this);
+                } catch (Throwable exception) {
+                    // The publisher is already closed or is
+                    if (closed.get()) {
+                        on.set(false);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void run() {
+            if (on.get()) {
+                try {
+                    final Signal s = inboundSignals.poll();
+                    if (s != null) {
+                        LOG.trace("processing: {}", s.getClass().getSimpleName());
+                        if (s == Send.Instance) {
+                            maySendNextRecords();
+                        }
+                        if (s == Complete.Instance) {
+                            try {
+                                mayDrainAllRecords();
+                            } finally {
+                                shutdown();
+                                inboundSignals.clear(); // do not process any signals after shutdown
+                            }
+                        }
+                        if (s instanceof SubscriptionSignal) {
+                            ((SubscriptionSignal)s).execute();
+                        }
+                    }
+                } finally {
+                    on.set(false);
+                    // do proceed if the last signal was not `Complete`
+                    if (!executor.isShutdown() && !inboundSignals.isEmpty()) {
+                        tryScheduleToExecute();
+                    }
+                }
+            }
+        }
+
+        private void shutdown() {
+            LOG.info("Shutting down event-loop");
+            executor.shutdown();
+        }
+
+        void awaitTerminationAndDoComplete(final Duration forceAfterTimeout) {
+            try {
+                executor.awaitTermination(forceAfterTimeout.toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException exception) {
+                executor.shutdownNow();
+                LOG.error("EventLoop failed to terminate before timeout, unsent events: {}", queue.size());
+            } finally {
+                subscriptions().forEach(EventStreamSubscription::doOnComplete);
+            }
+        }
+
+        private void mayDrainAllRecords() {
+            if (hasActiveSubscriptions() && hasMoreRecords()) {
+                // Try to send all remaining records before completing subscriptions.
+                Collection<KV<K, V>> records = new LinkedList<>();
+                queue.drainTo(records);
+                records.forEach(record -> {
+                    subscriptions().forEach(subscription -> {
+                        if (subscription.canReceived())
+                            subscription.doOnNext(record);
+                    });
+                });
+            }
+        }
+
+        private void maySendNextRecords() {
+            int sent = 0;
+            while (hasMoreRecords() && sent < MAX_POLL_RECORDS) {
+                // return immediately if no subscription can receive more records.
+                if (!hasActiveSubscriptions()) {
+                    LOG.trace("no subscription ready for next records. Signal ignored.");
+                    break;
+                }
+                KV<K, V> record = queue.poll();
+                subscriptions().forEach(subscription -> {
+                    if (subscription.canReceived())
+                        subscription.doOnNext(record);
+                });
+                sent++;
+            }
+        }
+    }
+
+    interface EventStreamSubscription<T> extends Flow.Subscription {
+        // MUST be executed only from the event-loop
+        void doOnNext(final T record);
+        // MUST be executed only from the event-loop
+        void doOnSubscribe();
+        // MUST be executed only from the event-loop
+        boolean canReceived();
+        // MUST be executed only from the event-loop
+        void doOnRequest(final long demands);
+        void doOnComplete();
+        void doOnCancel();
+    }
+
+    /**
+     * The internal {@link EventStreamSubscription} implementation.
+     */
+    private class InternalEventStreamSubscription implements EventStreamSubscription<KV<K, V>> {
+
+        private final Flow.Subscriber<? super KV<K, V>> subscriber;
+
+        private final SubscriptionId subscriptionId;
+
+        private long demands = 0L;
+
+        private boolean completed = false;
+
+        private boolean done = false;
+
+        InternalEventStreamSubscription(final Flow.Subscriber<? super KV<K, V>> subscriber,
+                                        final SubscriptionId subscriptionId) {
+            this.subscriber = subscriber;
+            this.subscriptionId = subscriptionId;
+        }
+
+        @Override
+        public boolean canReceived() {
+            return demands > 0 && !done;
+        }
+
+        @Override
+        public void doOnRequest(final long n) {
+            if (n < 1) { // rule 3.9
+                subscriber.onError(new IllegalArgumentException("non-positive request signals are illegal"));
+                return;
+            }
+
+            if (demands + n < 1) {
+                demands = Long.MAX_VALUE;
+            } else {
+                demands += n;
+            }
+            eventLoop.signal(Send.Instance);
+        }
+
+        private void decrementRequested() {
+            if (demands != Long.MAX_VALUE) // rule 3.17, i.e. unbounded
+                demands--;
+        }
+
+        @Override
+        public void doOnSubscribe() {
+            subscriptions.put(subscriptionId, this);
+            subscriber.onSubscribe(this);
+        }
+
+        @Override
+        public void doOnComplete() {
+            if (completed) return;
+
+            try {
+                doOnCancel(); // rule 1.6 - consider the Subscription cancelled when onComplete is signalled
+                subscriber.onComplete();
+                completed = true;
+            } catch (Exception e) {
+                LOG.error("Exception occurred while calling onComplete", e);
+            }
+        }
+
+        @Override
+        public void doOnCancel() {
+            subscriptions.remove(subscriptionId); // drop any reference to this subscription/subscriber
+            done = true;
+        }
+
+        @Override
+        public void doOnNext(final KV<K, V> record) {
+            try {
+                subscriber.onNext(record);
+                decrementRequested();
+            } catch (Exception e) {
+                LOG.error("Exception occurred while calling onNext", e);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void request(final long demands) {
+            if (completed) return; // rule 3.6
+            eventLoop.signal(new Request<>(this, demands));
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void cancel() {
+            if (done) return; // rule 3.7
+
+            // async help with rule 3.4
+            eventLoop.signal(new Cancel<>(this));
+        }
+
+        void init() {
+            eventLoop.signal(new Subscribe<>(this));
+        }
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/EventStreamPublisher.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/EventStreamPublisher.java
@@ -16,38 +16,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.streams.topology;
+package io.streamthoughts.azkarra.api.events.reactive;
 
+import io.streamthoughts.azkarra.api.events.BlockingRecordQueue;
 import io.streamthoughts.azkarra.api.events.EventStream;
-import org.apache.kafka.streams.Topology;
+import io.streamthoughts.azkarra.api.events.EventStreamProvider;
+import io.streamthoughts.azkarra.api.model.KV;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.concurrent.Flow;
 
-public interface TopologyDefinition {
-
-    /**
-     * @return  the topology name.
-     */
-    String getName();
-
-    /**
-     * @return  the topology version.
-     */
-    String getVersion();
-
-    /**
-     * @return the topology description.
-     */
-    String getDescription();
+/**
+ * The main publisher interface to subscribe to a specific streams of key-value records.
+ *
+ * @see EventStream
+ * @see EventStreamProvider
+ * @see BlockingRecordQueue
+ *
+ * @param <K>       the record key type.
+ * @param <V>       the record value type.
+ *
+ * @since 0.8.0
+ */
+public interface EventStreamPublisher<K, V> extends Flow.Publisher<KV<K, V>> {
 
     /**
-     * @return the {@link Topology}.
+     * Get the event type name attached to this publisher.
+     *
+     * @return the event type name.
      */
-    Topology getTopology();
+    String type();
 
-    default List<EventStream> getEventStreams() {
-        return Collections.emptyList();
-    }
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void subscribe(final Flow.Subscriber<? super KV<K, V>> subscriber);
 
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/internal/LongSubscriptionId.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/internal/LongSubscriptionId.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events.reactive.internal;
+
+import java.util.Objects;
+
+/**
+ * A long-based {@link SubscriptionId}.
+ *
+ * @since 0.8.0
+ */
+public class LongSubscriptionId implements SubscriptionId {
+
+    private final long id;
+
+    /**
+     * Creates a new {@link LongSubscriptionId} instance.
+     * @param id   the identifier.
+     */
+    LongSubscriptionId(final long id) {
+        this.id = id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object get() {
+        return id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LongSubscriptionId)) return false;
+        LongSubscriptionId that = (LongSubscriptionId) o;
+        return id == that.id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "LongSubscriptionId{id=" + id + '}';
+    }
+}

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/internal/SequentialSubscriptionIdGenerator.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/internal/SequentialSubscriptionIdGenerator.java
@@ -16,38 +16,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.streams.topology;
+package io.streamthoughts.azkarra.api.events.reactive.internal;
 
-import io.streamthoughts.azkarra.api.events.EventStream;
-import org.apache.kafka.streams.Topology;
+import java.util.concurrent.atomic.AtomicLong;
 
-import java.util.Collections;
-import java.util.List;
+/**
+ * Class that can be used to generate a sequential {@link SubscriptionId}.
+ *
+ * @since 0.8.0
+ */
+public class SequentialSubscriptionIdGenerator implements SubscriptionIdGenerator {
 
-public interface TopologyDefinition {
-
-    /**
-     * @return  the topology name.
-     */
-    String getName();
+    private final AtomicLong counter = new AtomicLong(0);
 
     /**
-     * @return  the topology version.
+     * {@inheritDoc}
      */
-    String getVersion();
-
-    /**
-     * @return the topology description.
-     */
-    String getDescription();
-
-    /**
-     * @return the {@link Topology}.
-     */
-    Topology getTopology();
-
-    default List<EventStream> getEventStreams() {
-        return Collections.emptyList();
+    @Override
+    public LongSubscriptionId generateNext() {
+        return new LongSubscriptionId(counter.getAndIncrement());
     }
-
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/internal/SubscriptionId.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/internal/SubscriptionId.java
@@ -16,38 +16,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.streams.topology;
+package io.streamthoughts.azkarra.api.events.reactive.internal;
 
-import io.streamthoughts.azkarra.api.events.EventStream;
-import org.apache.kafka.streams.Topology;
-
-import java.util.Collections;
-import java.util.List;
-
-public interface TopologyDefinition {
-
-    /**
-     * @return  the topology name.
-     */
-    String getName();
+/**
+ * Default interface that is used to wrap a subscription identifier.
+ *
+ * @since 0.8.0
+ */
+public interface SubscriptionId {
 
     /**
-     * @return  the topology version.
+     * @return the subscription identifier object.
      */
-    String getVersion();
-
-    /**
-     * @return the topology description.
-     */
-    String getDescription();
-
-    /**
-     * @return the {@link Topology}.
-     */
-    Topology getTopology();
-
-    default List<EventStream> getEventStreams() {
-        return Collections.emptyList();
-    }
+    Object get();
 
 }

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/internal/SubscriptionIdGenerator.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/events/reactive/internal/SubscriptionIdGenerator.java
@@ -16,38 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamthoughts.azkarra.api.streams.topology;
+package io.streamthoughts.azkarra.api.events.reactive.internal;
 
-import io.streamthoughts.azkarra.api.events.EventStream;
-import org.apache.kafka.streams.Topology;
-
-import java.util.Collections;
-import java.util.List;
-
-public interface TopologyDefinition {
+/**
+ * @since 0.8.0
+ */
+public interface SubscriptionIdGenerator {
 
     /**
-     * @return  the topology name.
+     * Generates the next {@link SubscriptionId}
+     *
+     * @return  a new {@link SubscriptionId}.
      */
-    String getName();
-
-    /**
-     * @return  the topology version.
-     */
-    String getVersion();
-
-    /**
-     * @return the topology description.
-     */
-    String getDescription();
-
-    /**
-     * @return the {@link Topology}.
-     */
-    Topology getTopology();
-
-    default List<EventStream> getEventStreams() {
-        return Collections.emptyList();
-    }
-
+    SubscriptionId generateNext();
 }

--- a/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/events/BasicBlockingRecordQueueTest.java
+++ b/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/events/BasicBlockingRecordQueueTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events;
+
+import io.streamthoughts.azkarra.api.events.callback.QueueCallback;
+import io.streamthoughts.azkarra.api.model.KV;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class BasicBlockingRecordQueueTest {
+
+    private static final KV<Object, Object> TEST_KV = KV.of("key", "value1");
+
+    @Test
+    public void shouldInvokedLimitHandlerWhenQueueLimitIsReached() {
+        // Given
+        var queue = new BasicBlockingRecordQueue<>(1);
+        var limitReached = new AtomicBoolean(false);
+        queue.setLimitHandler(new LimitHandler() {
+            @Override
+            public <K, V> void onLimitReached(final BlockingRecordQueue<K, V> queue) {
+                limitReached.set(true);
+            }
+        });
+        // When
+        queue.send(TEST_KV);
+        // Then
+        Assertions.assertTrue(limitReached.get());
+    }
+
+    @Test
+    public void shouldReturnLastSendRecordOnPollGivenNonEmptyQueue() {
+        // Given
+        var queue = new BasicBlockingRecordQueue<>();
+        queue.send(TEST_KV);
+        Assertions.assertFalse(queue.isEmpty());
+        // When/Then
+        Assertions.assertEquals(TEST_KV, queue.poll());
+    }
+
+    @Test
+    public void shouldNotAddRecordToQueueGivenNull() {
+        // Given
+        var queue = new BasicBlockingRecordQueue<>();
+        // When
+        queue.send(null);
+        // Then
+        Assertions.assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    public void shouldNotAddRecordWhenQueueIsClosed() {
+        // Given
+        var queue = new BasicBlockingRecordQueue<>();
+        // When
+        queue.close();
+        // Then
+        queue.send(TEST_KV);
+        Assertions.assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    public void shouldInvokeQueueCallbackWhenQueueIsClosed() {
+        // Given
+        var queue = new BasicBlockingRecordQueue<>();
+        var called = new AtomicBoolean(false);
+        queue.setQueueCallback(new QueueCallback() {
+            @Override
+            public void onClosed() {
+                called.set(true);
+            }
+
+            @Override
+            public void onQueued() {
+
+            }
+        });
+
+        // When
+        queue.close();
+
+        // Then
+        Assertions.assertTrue(called.get());
+    }
+
+    @Test
+    public void shouldInvokeQueueCallbackWhenRecordIsQueued() {
+        // Given
+        var queue = new BasicBlockingRecordQueue<>();
+        var queued = new AtomicBoolean(false);
+        queue.setQueueCallback(new QueueCallback() {
+            @Override
+            public void onClosed() {
+            }
+
+            @Override
+            public void onQueued() {
+                queued.set(true);
+            }
+        });
+        // When
+        queue.send(TEST_KV);
+
+        // Then
+        Assertions.assertTrue(queued.get());
+    }
+}

--- a/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/events/callback/LimitedQueueCallbackTest.java
+++ b/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/events/callback/LimitedQueueCallbackTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events.callback;
+
+import io.streamthoughts.azkarra.api.events.BlockingRecordQueue;
+import io.streamthoughts.azkarra.api.events.LimitHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class LimitedQueueCallbackTest {
+
+    @Test
+    public void shouldInvokeLimitHandlerWhenLimitIsReached() {
+        // Given
+        LimitedQueueCallback callback = new LimitedQueueCallback(1);
+        // When
+        var limitReached = new AtomicBoolean(false);
+        callback.setLimitHandler(new LimitHandler() {
+            @Override
+            public <K, V> void onLimitReached(final BlockingRecordQueue<K, V> queue) {
+                limitReached.set(true);
+            }
+        });
+        callback.onQueued();
+        // Then
+        Assertions.assertTrue(limitReached.get());
+    }
+}

--- a/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/events/reactive/AsyncMulticastEventStreamPublisherTest.java
+++ b/azkarra-api/src/test/java/io/streamthoughts/azkarra/api/events/reactive/AsyncMulticastEventStreamPublisherTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events.reactive;
+
+import io.streamthoughts.azkarra.api.events.BasicBlockingRecordQueue;
+import io.streamthoughts.azkarra.api.events.EventStream;
+import io.streamthoughts.azkarra.api.model.KV;
+import io.streamthoughts.azkarra.api.time.SystemTime;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Flow;
+
+public class AsyncMulticastEventStreamPublisherTest {
+
+    private static final int DEFAULT_TIMEOUT_MS = 200;
+
+    @Test
+    public void test(){
+        AsyncMulticastEventStreamPublisher<String, Long> publisher = createPublisher(5);
+        CaptureSubscriber<String, Long> subscriber = new CaptureSubscriber<>();
+        publisher.subscribe(subscriber);
+        waitAndAssertReceived(subscriber, 0);
+        subscriber.subscription.request(1);
+        waitAndAssertReceived(subscriber, 1);
+        subscriber.subscription.request(1);
+        subscriber.subscription.request(2);
+        waitAndAssertReceived(subscriber, 4);
+    }
+
+    private void waitAndAssertReceived(final CaptureSubscriber<String, Long> subscriber, int expected) {
+        SystemTime.SYSTEM.sleep(Duration.ofMillis(DEFAULT_TIMEOUT_MS));
+        Assertions.assertEquals(expected, subscriber.received.size());
+    }
+
+    private AsyncMulticastEventStreamPublisher<String, Long> createPublisher(long elements) {
+        var queue = new BasicBlockingRecordQueue<String, Long>(Integer.MAX_VALUE);
+        EventStream<String, Long> stream = new EventStream<>("test", queue);
+        var publisher = new AsyncMulticastEventStreamPublisher<>(stream);
+        if (elements < Integer.MAX_VALUE) {
+            for (long l = 0; l < elements; l++) {
+                stream.send(KV.of("key", l));
+            }
+        }
+        return publisher;
+    }
+
+    public class CaptureSubscriber<K, V> implements Flow.Subscriber<KV<K, V>> {
+
+        List<KV<K, V>> received = new LinkedList<>();
+        Flow.Subscription subscription;
+        Throwable throwable;
+        boolean complete = false;
+
+        @Override
+        public void onSubscribe(final Flow.Subscription subscription) {
+            this.subscription = subscription;
+        }
+
+        @Override
+        public void onNext(final KV<K, V> record) {
+            received.add(record);
+        }
+
+        @Override
+        public void onError(final Throwable throwable) {
+            this.throwable = throwable;
+        }
+
+        @Override
+        public void onComplete() {
+            complete = true;
+        }
+    }
+}

--- a/azkarra-examples/src/main/java/io/streamthoughts/examples/azkarra/sse/ServerSentEventExample.java
+++ b/azkarra-examples/src/main/java/io/streamthoughts/examples/azkarra/sse/ServerSentEventExample.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.examples.azkarra.sse;
+
+import io.streamthoughts.azkarra.api.annotations.Component;
+import io.streamthoughts.azkarra.api.events.EventStreamSupport;
+import io.streamthoughts.azkarra.api.events.LimitHandlers;
+import io.streamthoughts.azkarra.api.streams.TopologyProvider;
+import io.streamthoughts.azkarra.streams.AzkarraApplication;
+import io.streamthoughts.azkarra.streams.autoconfigure.annotations.AzkarraStreamsApplication;
+import io.streamthoughts.examples.azkarra.Version;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.KeyValueStore;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+@AzkarraStreamsApplication
+public class ServerSentEventExample {
+
+    public static void main(String[] args) {
+        AzkarraApplication.run(ServerSentEventExample.class, args);
+    }
+
+    @Component
+    public static class WordCountPublisherTopology extends EventStreamSupport implements TopologyProvider {
+
+        @Override
+        public String version() {
+            return Version.getVersion();
+        }
+
+        @Override
+        public Topology get() {
+            setDefaultEventQueueSize(10_000);
+            setDefaultEventQueueLimitHandler(LimitHandlers.dropHeadOnLimitReached());
+            addEventStreamsWithDefaults("word"); // register a default event-streams for type named 'word'
+
+            final StreamsBuilder builder = new StreamsBuilder();
+
+            final KStream<String, String> source = builder.stream("streams-plaintext-input");
+
+            final KTable<String, Long> counts = source
+                .flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\s")))
+
+                .groupBy((key, value) -> value)
+                .count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("count").withCachingDisabled());
+
+            // Use the EventStreamSupport#send method to publish all key-value records for type 'word'
+            counts
+                .toStream()
+                .foreach( (k, v) -> send("word", k, v));
+
+            return builder.build();
+        }
+    }
+}

--- a/azkarra-reactive-tck/PublisherVerification.required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements
+++ b/azkarra-reactive-tck/PublisherVerification.required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements
@@ -1,0 +1,80 @@
+[INFO] Scanning for projects...
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for io.streamthoughts:azkarra-api-reactive-tck:jar:0.8.0-SNAPSHOT
+[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 21, column 21
+[WARNING] 
+[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
+[WARNING] 
+[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
+[WARNING] 
+[INFO] 
+[INFO] -------------< io.streamthoughts:azkarra-api-reactive-tck >-------------
+[INFO] Building azkarra-api-reactive-tck 0.8.0-SNAPSHOT
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- maven-checkstyle-plugin:3.1.0:check (validate) @ azkarra-api-reactive-tck ---
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ azkarra-api-reactive-tck ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] Copying 0 resource
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.8.0:compile (default-compile) @ azkarra-api-reactive-tck ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO] 
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ azkarra-api-reactive-tck ---
+[INFO] Using 'UTF-8' encoding to copy filtered resources.
+[INFO] skip non existing resourceDirectory /home/florian/Workspace/GitHub/azkarra-streams/azkarra-api-reactive-tck/src/test/resources
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.8.0:testCompile (default-testCompile) @ azkarra-api-reactive-tck ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO] 
+[INFO] --- maven-surefire-plugin:3.0.0-M3:test (default-test) @ azkarra-api-reactive-tck ---
+[INFO] 
+[INFO] -------------------------------------------------------
+[INFO]  T E S T S
+[INFO] -------------------------------------------------------
+[INFO] Running io.streamthoughts.azkarra.api.events.reactive.AsyncMulticastEventStreamPublisherVerificationTest
+[ERROR] Tests run: 38, Failures: 4, Errors: 0, Skipped: 12, Time elapsed: 42.176 s <<< FAILURE! - in io.streamthoughts.azkarra.api.events.reactive.AsyncMulticastEventStreamPublisherVerificationTest
+[ERROR] required_createPublisher3MustProduceAStreamOfExactly3Elements(io.streamthoughts.azkarra.api.events.reactive.AsyncMulticastEventStreamPublisherVerificationTest)  Time elapsed: 0.205 s  <<< FAILURE!
+java.lang.AssertionError: Publisher org.reactivestreams.FlowAdapters$ReactivePublisherFromFlow@75437611 produced only 1 element expected [true] but found [false]
+
+[ERROR] required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements(io.streamthoughts.azkarra.api.events.reactive.AsyncMulticastEventStreamPublisherVerificationTest)  Time elapsed: 3.002 s  <<< FAILURE!
+java.lang.AssertionError: Publisher org.reactivestreams.FlowAdapters$ReactivePublisherFromFlow@cc43f62 produced less than 3 elements after two respective `request` calls within 1000 ms
+Caused by: java.lang.AssertionError: Publisher org.reactivestreams.FlowAdapters$ReactivePublisherFromFlow@cc43f62 produced less than 3 elements after two respective `request` calls within 1000 ms
+
+[ERROR] required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates(io.streamthoughts.azkarra.api.events.reactive.AsyncMulticastEventStreamPublisherVerificationTest)  Time elapsed: 0.202 s  <<< FAILURE!
+java.lang.AssertionError: Expected element but got end-of-stream
+Caused by: java.lang.AssertionError: Expected element but got end-of-stream
+
+[ERROR] required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue(io.streamthoughts.azkarra.api.events.reactive.AsyncMulticastEventStreamPublisherVerificationTest)  Time elapsed: 0.203 s  <<< FAILURE!
+java.lang.AssertionError: Expected element but got end-of-stream
+Caused by: java.lang.AssertionError: Expected element but got end-of-stream
+
+[INFO] 
+[INFO] Results:
+[INFO] 
+[ERROR] Failures: 
+[ERROR]   AsyncMulticastEventStreamPublisherVerificationTest>PublisherVerification.required_createPublisher3MustProduceAStreamOfExactly3Elements:179->PublisherVerification.activePublisherTest:1142 Publisher org.reactivestreams.FlowAdapters$ReactivePublisherFromFlow@75437611 produced only 1 element expected [true] but found [false]
+[ERROR]   AsyncMulticastEventStreamPublisherVerificationTest>PublisherVerification.required_spec101_subscriptionRequestMustResultInTheCorrectNumberOfProducedElements:211->PublisherVerification.activePublisherTest:1142 Publisher org.reactivestreams.FlowAdapters$ReactivePublisherFromFlow@cc43f62 produced less than 3 elements after two respective `request` calls within 1000 ms
+[ERROR]   AsyncMulticastEventStreamPublisherVerificationTest>PublisherVerification.required_spec105_mustSignalOnCompleteWhenFiniteStreamTerminates:397->PublisherVerification.activePublisherTest:1142 Expected element but got end-of-stream
+[ERROR]   AsyncMulticastEventStreamPublisherVerificationTest>PublisherVerification.required_spec317_mustSupportACumulativePendingElementCountUpToLongMaxValue:1055->PublisherVerification.activePublisherTest:1142 Expected element but got end-of-stream
+[INFO] 
+[ERROR] Tests run: 38, Failures: 4, Errors: 0, Skipped: 12
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD FAILURE
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  44.262 s
+[INFO] Finished at: 2020-07-09T18:58:47+02:00
+[INFO] ------------------------------------------------------------------------
+[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M3:test (default-test) on project azkarra-api-reactive-tck: There are test failures.
+[ERROR] 
+[ERROR] Please refer to /home/florian/Workspace/GitHub/azkarra-streams/azkarra-api-reactive-tck/target/surefire-reports for the individual test results.
+[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
+[ERROR] -> [Help 1]
+[ERROR] 
+[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+[ERROR] Re-run Maven using the -X switch to enable full debug logging.
+[ERROR] 
+[ERROR] For more information about the errors and possible solutions, please read the following articles:
+[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

--- a/azkarra-reactive-tck/pom.xml
+++ b/azkarra-reactive-tck/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>azkarra-streams-reactor</artifactId>
+        <groupId>io.streamthoughts</groupId>
+        <version>0.8.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>azkarra-reactive-tck</artifactId>
+
+    <properties>
+        <checkstyle.config.location>${project.parent.basedir}</checkstyle.config.location>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.streamthoughts</groupId>
+            <artifactId>azkarra-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.streamthoughts</groupId>
+            <artifactId>azkarra-server</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams-tck-flow</artifactId>
+            <version>1.0.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.9.8</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/azkarra-reactive-tck/src/test/java/io/streamthoughts/azkarra/api/events/reactive/AsyncMulticastEventStreamPublisherVerificationTest.java
+++ b/azkarra-reactive-tck/src/test/java/io/streamthoughts/azkarra/api/events/reactive/AsyncMulticastEventStreamPublisherVerificationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events.reactive;
+
+import io.streamthoughts.azkarra.api.events.BasicBlockingRecordQueue;
+import io.streamthoughts.azkarra.api.events.BlockingRecordQueue;
+import io.streamthoughts.azkarra.api.events.DelegateBlockingRecordQueue;
+import io.streamthoughts.azkarra.api.events.EventStream;
+import io.streamthoughts.azkarra.api.model.KV;
+import io.streamthoughts.azkarra.api.time.SystemTime;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowPublisherVerification;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.Flow;
+
+public class AsyncMulticastEventStreamPublisherVerificationTest extends FlowPublisherVerification<KV<String, Long>> {
+
+    public AsyncMulticastEventStreamPublisherVerificationTest() {
+        super(new TestEnvironment(200));
+    }
+
+    @Override
+    public Flow.Publisher<KV<String, Long>> createFlowPublisher(long elements) {
+        var queue = new AutoCloseBlockingRecordQueue<String, Long>(new BasicBlockingRecordQueue<>(Integer.MAX_VALUE));
+        //var queue = new BasicBlockingRecordQueue<String, Long>(Integer.MAX_VALUE);
+        EventStream<String, Long> stream = new EventStream<>("test", queue);
+        var publisher = new AsyncMulticastEventStreamPublisher<>(stream);
+        if (elements < Integer.MAX_VALUE) {
+            for (long l = 0; l < elements; l++) {
+                stream.send(KV.of("key", l));
+            }
+        }
+        return publisher;
+    }
+
+    @Override
+    public Flow.Publisher<KV<String, Long>> createFailedFlowPublisher() {
+        return null;
+    }
+
+    @Override
+    public long maxElementsFromPublisher() {
+        return Integer.MAX_VALUE - 1;
+    }
+
+    @Override
+    public long boundedDepthOfOnNextAndRequestRecursion() {
+        return 1;
+    }
+
+    public static class AutoCloseBlockingRecordQueue<K, V> extends DelegateBlockingRecordQueue<K, V> {
+
+
+        AutoCloseBlockingRecordQueue(final BlockingRecordQueue<K, V> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public KV<K, V> poll(Duration timeout) throws InterruptedException {
+            KV<K, V> r = super.poll(timeout);
+            mayScheduleClose();
+            return r;
+        }
+
+        @Override
+        public KV<K, V> poll() {
+            KV<K, V> r = super.poll();
+            mayScheduleClose();
+            return r;
+        }
+
+        @Override
+        public void drainTo(Collection<? super KV<K, V>> collection) {
+            super.drainTo(collection);
+        }
+
+        private void mayScheduleClose() {
+            if (isEmpty()) {
+                new Thread(() -> {
+                    SystemTime.SYSTEM.sleep(Duration.ofMillis(100));
+                    close();
+                }).start();
+            }
+        }
+    }
+}

--- a/azkarra-reactive-tck/src/test/java/io/streamthoughts/azkarra/api/events/reactive/SSEFlowSubscriberBlackboxVerificationTest.java
+++ b/azkarra-reactive-tck/src/test/java/io/streamthoughts/azkarra/api/events/reactive/SSEFlowSubscriberBlackboxVerificationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.api.events.reactive;
+
+import io.streamthoughts.azkarra.api.model.KV;
+import io.streamthoughts.azkarra.http.sse.ServerSentEventSubscriber;
+import io.streamthoughts.azkarra.serialization.json.Json;
+import io.undertow.server.handlers.sse.ServerSentEventConnection;
+import org.mockito.Mockito;
+import org.reactivestreams.tck.TestEnvironment;
+import org.reactivestreams.tck.flow.FlowSubscriberBlackboxVerification;
+
+import java.util.concurrent.Flow;
+
+public class SSEFlowSubscriberBlackboxVerificationTest extends FlowSubscriberBlackboxVerification<KV<String, Integer>> {
+
+    protected SSEFlowSubscriberBlackboxVerificationTest() {
+        super(new TestEnvironment(200));
+    }
+
+    @Override
+    public Flow.Subscriber<KV<String, Integer>> createFlowSubscriber() {
+        return new ServerSentEventSubscriber<>(
+            Mockito.mock(ServerSentEventConnection.class),
+            "test",
+            "app",
+            Json.getDefault()
+        );
+    }
+
+    @Override
+    public KV<String, Integer> createElement(int elements) {
+        return KV.of("key", elements);
+    }
+}

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/context/internal/ContextAwareTopologySupplier.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/context/internal/ContextAwareTopologySupplier.java
@@ -27,10 +27,15 @@ import io.streamthoughts.azkarra.api.components.qualifier.Qualifiers;
 import io.streamthoughts.azkarra.api.config.Conf;
 import io.streamthoughts.azkarra.api.config.Configurable;
 import io.streamthoughts.azkarra.api.config.ConfigurableSupplier;
+import io.streamthoughts.azkarra.api.events.EventStream;
+import io.streamthoughts.azkarra.api.events.EventStreamProvider;
 import io.streamthoughts.azkarra.api.providers.TopologyDescriptor;
 import io.streamthoughts.azkarra.api.streams.TopologyProvider;
 import io.streamthoughts.azkarra.api.util.ClassUtils;
 import org.apache.kafka.streams.Topology;
+
+import java.util.Collections;
+import java.util.List;
 
 public class ContextAwareTopologySupplier extends ConfigurableSupplier<TopologyProvider> {
 
@@ -77,7 +82,7 @@ public class ContextAwareTopologySupplier extends ConfigurableSupplier<TopologyP
      */
     public static class ClassLoaderAwareTopologyProvider
             extends DelegatingExecutionEnvironmentAware<TopologyProvider>
-            implements TopologyProvider, StreamsExecutionEnvironmentAware {
+            implements TopologyProvider, StreamsExecutionEnvironmentAware, EventStreamProvider {
 
         private final ClassLoader topologyClassLoader;
 
@@ -107,6 +112,17 @@ public class ContextAwareTopologySupplier extends ConfigurableSupplier<TopologyP
             } finally {
                 ClassUtils.compareAndSwapLoaders(classLoader);
             }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public List<EventStream> getEventStreams() {
+            if (delegate instanceof EventStreamProvider) {
+                return ((EventStreamProvider)delegate).getEventStreams();
+            }
+            return Collections.emptyList();
         }
     }
 }

--- a/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/env/DefaultStreamsExecutionEnvironmentTest.java
+++ b/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/env/DefaultStreamsExecutionEnvironmentTest.java
@@ -23,7 +23,6 @@ import io.streamthoughts.azkarra.api.config.Conf;
 import io.streamthoughts.azkarra.api.config.Configurable;
 import io.streamthoughts.azkarra.api.streams.TopologyProvider;
 import io.streamthoughts.azkarra.api.streams.topology.TopologyDefinition;
-import io.streamthoughts.azkarra.api.streams.topology.TopologyMetadata;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
 import org.junit.jupiter.api.Test;
@@ -62,16 +61,17 @@ public class DefaultStreamsExecutionEnvironmentTest {
                 "default.prop", "override"
             ));
 
-        var definition = environment.new InternalTopologyDefinition(
+        var holder = environment.new TopologyDefinitionHolder(
             DummyTopologyProvider::new,
             executed);
 
-        assertEquals(MOCK, definition.topology());
+        var definition = holder.createTopologyDefinition();
+        assertEquals(MOCK, definition.getTopology());
 
-        assertEquals("dummy-topology",  definition.name());
-        assertEquals("a test topology",  definition.description());
+        assertEquals("dummy-topology",  definition.getName());
+        assertEquals("a test topology",  definition.getDescription());
 
-        Conf streams = definition.getTopologyConfig().getSubConf("streams");
+        Conf streams = holder.getTopologyConfig().getSubConf("streams");
         assertEquals("value", streams.getString("prop") );
         assertEquals("value", streams.getString("user.prop") );
         assertEquals("override", streams.getString("default.prop") );

--- a/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/ExchangeHelper.java
+++ b/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/ExchangeHelper.java
@@ -44,7 +44,7 @@ public class ExchangeHelper {
 
     private static final String CONTENT_TYPE = "application/json; charset=utf-8";
 
-    static final Json JSON = new Json(new ObjectMapper());
+    public static final Json JSON = new Json(new ObjectMapper());
 
     static {
         final SimpleModule module = new SimpleModule();

--- a/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/routes/ApiStreamsRoutes.java
+++ b/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/routes/ApiStreamsRoutes.java
@@ -20,6 +20,7 @@ package io.streamthoughts.azkarra.http.routes;
 
 import io.streamthoughts.azkarra.api.AzkarraStreamsService;
 import io.streamthoughts.azkarra.http.APIVersions;
+import io.streamthoughts.azkarra.http.ExchangeHelper;
 import io.streamthoughts.azkarra.http.handler.StreamsDeleteHandler;
 import io.streamthoughts.azkarra.http.handler.StreamsGetConfigHandler;
 import io.streamthoughts.azkarra.http.handler.StreamsGetDetailsHandler;
@@ -31,6 +32,7 @@ import io.streamthoughts.azkarra.http.handler.StreamsPostHandler;
 import io.streamthoughts.azkarra.http.handler.StreamsRestartHandler;
 import io.streamthoughts.azkarra.http.handler.StreamsStopHandler;
 import io.streamthoughts.azkarra.http.spi.RoutingHandlerProvider;
+import io.streamthoughts.azkarra.http.sse.EventStreamConnectionCallback;
 import io.undertow.Handlers;
 import io.undertow.server.RoutingHandler;
 import io.undertow.server.handlers.BlockingHandler;
@@ -62,6 +64,8 @@ public class ApiStreamsRoutes implements RoutingHandlerProvider {
             = "/streams/{id}/restart";
     private static final String PATH_STREAMS_STOP
             = "/streams/{id}/stop";
+    private static final String PATH_STREAMS_SSE
+            = "/streams/{id}/subscribe/{event}";
 
     /**
      * Creates a new {@link ApiStreamsRoutes} instance.
@@ -99,6 +103,9 @@ public class ApiStreamsRoutes implements RoutingHandlerProvider {
             .get(APIVersions.PATH_V1 + PATH_STREAMS_METRICS, metricsHandler)
             .get(APIVersions.PATH_V1 + PATH_STREAMS_METRICS_GROUP, metricsHandler)
             .get(APIVersions.PATH_V1 + PATH_STREAMS_METRICS_GROUP_METRIC, metricsHandler)
-            .get(APIVersions.PATH_V1 + PATH_STREAMS_METRICS_GROUP_METRIC_VALUE, metricsHandler);
+            .get(APIVersions.PATH_V1 + PATH_STREAMS_METRICS_GROUP_METRIC_VALUE, metricsHandler)
+            .get(APIVersions.PATH_V1 + PATH_STREAMS_SSE,
+                Handlers.serverSentEvents(new EventStreamConnectionCallback(service, ExchangeHelper.JSON))
+            );
     }
 }

--- a/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/sse/EventStreamConnectionCallback.java
+++ b/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/sse/EventStreamConnectionCallback.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.http.sse;
+
+import io.streamthoughts.azkarra.api.AzkarraStreamsService;
+import io.streamthoughts.azkarra.api.errors.NotFoundException;
+import io.streamthoughts.azkarra.api.events.reactive.EventStreamPublisher;
+import io.streamthoughts.azkarra.api.streams.KafkaStreamsContainer;
+import io.streamthoughts.azkarra.serialization.json.Json;
+import io.undertow.server.handlers.sse.ServerSentEventConnection;
+import io.undertow.server.handlers.sse.ServerSentEventConnectionCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @since 0.8.0
+ */
+public class EventStreamConnectionCallback implements ServerSentEventConnectionCallback {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EventStreamConnectionCallback.class);
+
+    private final AzkarraStreamsService service;
+
+    private final Json json;
+
+    /**
+     * Creates a new {@link EventStreamConnectionCallback} instance.
+     *
+     * @param service   the {@link AzkarraStreamsService} instance.
+     */
+    public EventStreamConnectionCallback(final AzkarraStreamsService service,
+                                         final Json json) {
+        this.service = service;
+        this.json = json;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void connected(final ServerSentEventConnection connection,
+                          final String lastEventId) {
+        var applicationId = connection.getParameter("id");
+        var eventChannel = connection.getParameter("event");
+        LOG.info(
+            "ServerSentEventConnection established. Subscribe to event-stream for application='{}', type='{}'",
+            applicationId,
+            eventChannel
+        );
+
+        try {
+            final KafkaStreamsContainer container = service.getStreamsById(applicationId);
+            final EventStreamPublisher publisher = container.getEventStreamPublisher(eventChannel);
+            if (publisher == null) {
+                connection.shutdown();
+                return;
+            }
+            publisher.subscribe(new ServerSentEventSubscriber<>(connection, publisher.type(), applicationId, json));
+
+        } catch (NotFoundException e) {
+            LOG.error(e.getMessage());
+            connection.shutdown();
+        }
+    }
+}

--- a/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/sse/ServerSentEventSubscriber.java
+++ b/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/sse/ServerSentEventSubscriber.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.http.sse;
+
+import io.streamthoughts.azkarra.api.model.KV;
+import io.streamthoughts.azkarra.serialization.json.Json;
+import io.undertow.server.handlers.sse.ServerSentEventConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.Flow;
+
+/**
+ * A subscriber that sent published {@link KV} records over HTTP using a Server-Sent Event (SSE) connection.
+ *
+ * @param <K>   the record-key type
+ * @param <V>   the record-value type.
+ *
+ * @since 0.8.0
+ */
+public class ServerSentEventSubscriber<K, V> implements Flow.Subscriber<KV<K, V>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerSentEventSubscriber.class);
+
+    private final String eventType;
+    private final ServerSentEventConnection connection;
+    private final String applicationId;
+    private Flow.Subscription subscription;
+    private final Json json;
+
+    /**
+     * Creates a new {@link ServerSentEventSubscriber} instance.
+     *
+     * @param connection    the {@link ServerSentEventConnection}.
+     * @param eventType     the event type.
+     * @param applicationId the {@code application.id} of KafkaStreams, used for logging.
+     * @param json          the {@link Json} serializer.
+     */
+    public ServerSentEventSubscriber(final ServerSentEventConnection connection,
+                                     final String eventType,
+                                     final String applicationId,
+                                     final Json json) {
+        this.connection = connection;
+        this.eventType = eventType;
+        this.applicationId = applicationId;
+        this.json = json;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onSubscribe(final Flow.Subscription subscription) {
+        Objects.requireNonNull(subscription); // rule 2.13
+        if (this.subscription != null) {
+            subscription.cancel(); // Cancel the additional subscription
+        } else {
+            this.subscription = subscription;
+            subscription.request(Long.MAX_VALUE);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onNext(final KV<K, V> record) {
+        Objects.requireNonNull(record); // rule 2.13
+        if (connection.isOpen()) {
+            final String payload = json.serialize(StreamedEvent.record(record));
+            connection.send(payload, eventType, null, new ServerSentEventConnection.EventCallback() {
+                @Override
+                public void done(final ServerSentEventConnection connection,
+                                 final String data,
+                                 final String event,
+                                 final String id) {
+                    LOG.debug(
+                        "Event sent for application='{}', type='{}'",
+                        applicationId,
+                        eventType
+                    );
+                }
+
+                @Override
+                public void failed(final ServerSentEventConnection connection,
+                                   final String data,
+                                   final String event,
+                                   final String id,
+                                   final IOException e) {
+                    LOG.debug(
+                        "Failed to send event for application='{}', type='{}'",
+                        applicationId,
+                        eventType
+                    );
+                }
+            });
+        } else {
+            subscription.cancel(); // Cancel the subscription if the connection is closed.
+            LOG.info(
+                "ServerSentEventConnection was closed. Canceling subscription for application='{}', type='{}'.",
+                applicationId,
+                eventType
+            );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onError(final Throwable throwable) {
+        Objects.requireNonNull(throwable); // rule 2.13
+        LOG.error("Unexpected error while consuming from . Closing ServerSentEventConnection", throwable);
+        closeConnection();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onComplete() {
+        LOG.info(
+            "Closing ServerSentEventConnection for application='{}', type='{}'",
+            applicationId,
+            eventType
+        );
+        closeConnection();
+    }
+
+    private void closeConnection() {
+        connection.shutdown();
+    }
+
+    public static class StreamedEvent {
+
+        private final  KV<?, ?> record;
+
+        public static StreamedEvent record(final KV<?, ?> record) {
+            return new StreamedEvent(record);
+        }
+
+        public StreamedEvent(final KV<?, ?> record) {
+            this.record = record;
+        }
+
+        public KV getRecord() {
+            return record;
+        }
+    }
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 
     <modules>
         <module>azkarra-api</module>
+        <module>azkarra-reactive-tck</module>
         <module>azkarra-runtime</module>
         <module>azkarra-streams</module>
         <module>azkarra-ui</module>


### PR DESCRIPTION
This commit introduces new API to stream records directly from
KafkaStreams to a front app using HTTP server-sent event.

Changes:
 - add new package io.streamthoughts.azkarra.api.events
 - add new endpoint : /api/v1/streams/:id/subscribe/:type

Resolves: GH-100