### PR TITLE
feat(runtime): add new KafkaBrokerReadyInterceptor (#51)

### DIFF
--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/streams/KafkaStreamsContainerBuilder.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/streams/KafkaStreamsContainerBuilder.java
@@ -197,8 +197,8 @@ public class KafkaStreamsContainerBuilder {
             compositeStateListener.addListener((newState, oldState) -> {
                 final StateChangeEvent event = new StateChangeEvent(
                     Time.SYSTEM.milliseconds(),
-                    State.valueOf(newState.name()),
-                    State.valueOf(oldState.name())
+                    State.Standards.valueOf(newState.name()),
+                    State.Standards.valueOf(oldState.name())
                 );
                 container.stateChanges(event);
             });

--- a/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/streams/State.java
+++ b/azkarra-api/src/main/java/io/streamthoughts/azkarra/api/streams/State.java
@@ -21,57 +21,58 @@ package io.streamthoughts.azkarra.api.streams;
 import org.apache.kafka.streams.KafkaStreams;
 
 /**
- * The status for a {@link KafkaStreams} instance.
- *
- * @see KafkaStreams.State
- * @see KafkaStreamsContainer
+ * Interface that can be used to set the state of the {@link KafkaStreamsContainer}.
  */
-public enum State {
+public interface State {
+
+    String name();
 
     /**
-     * The {@link KafkaStreams} instance has been created yet.
+     * The standard {@link State} for a {@link KafkaStreams} instance.
+     *
+     * @see KafkaStreams.State
+     * @see KafkaStreamsContainer
      */
-    NOT_CREATED,
+    enum Standards implements State {
 
-    /**
-     * The {@link KafkaStreams} instance has been created successfully.
-     */
-    CREATED,
+        /**
+         * The {@link KafkaStreams} instance has been created yet.
+         */
+        NOT_CREATED,
 
-    /**
-     * The {@link KafkaStreamsContainer} is waiting for sources
-     * topics to be created before starting {@link KafkaStreams} instance.
-     */
-    WAITING_FOR_TOPICS,
+        /**
+         * The {@link KafkaStreams} instance has been created successfully.
+         */
+        CREATED,
 
-    /**
-     * @see KafkaStreams.State#REBALANCING
-     */
-    REBALANCING,
+        /**
+         * @see KafkaStreams.State#REBALANCING
+         */
+        REBALANCING,
 
-    /**
-     * @see KafkaStreams.State#RUNNING
-     */
-    RUNNING,
+        /**
+         * @see KafkaStreams.State#RUNNING
+         */
+        RUNNING,
 
-    /**
-     * @see KafkaStreams.State#PENDING_SHUTDOWN
-     */
-    PENDING_SHUTDOWN,
+        /**
+         * @see KafkaStreams.State#PENDING_SHUTDOWN
+         */
+        PENDING_SHUTDOWN,
 
-    /**
-     * @see KafkaStreams.State#NOT_RUNNING
-     */
-    NOT_RUNNING,
+        /**
+         * @see KafkaStreams.State#NOT_RUNNING
+         */
+        NOT_RUNNING,
 
-    /**
-     * The {@link KafkaStreamsContainer} shutdown is complete.
-     */
-    STOPPED,
+        /**
+         * The {@link KafkaStreamsContainer} shutdown is complete.
+         */
+        STOPPED,
 
-    /**
-     * @see KafkaStreams.State#ERROR
-     */
-    ERROR
-
+        /**
+         * @see KafkaStreams.State#ERROR
+         */
+        ERROR
+    }
 }

--- a/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/interceptor/MeterKafkaStreamsInterceptor.java
+++ b/azkarra-metrics/src/main/java/io/streamthoughts/azkarra/metrics/interceptor/MeterKafkaStreamsInterceptor.java
@@ -76,7 +76,7 @@ public class MeterKafkaStreamsInterceptor extends BaseComponentModule implements
             context.addStateChangeWatcher(new KafkaStreamsContainer.StateChangeWatcher() {
                 @Override
                 public boolean accept(final State newState) {
-                    return newState == State.RUNNING;
+                    return newState == State.Standards.RUNNING;
                 }
 
                 @Override

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/context/DefaultAzkarraContext.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/context/DefaultAzkarraContext.java
@@ -61,6 +61,7 @@ import io.streamthoughts.azkarra.runtime.context.internal.ContextAwareTopologySu
 import io.streamthoughts.azkarra.runtime.env.DefaultStreamsExecutionEnvironment;
 import io.streamthoughts.azkarra.runtime.interceptors.AutoCreateTopicsInterceptor;
 import io.streamthoughts.azkarra.runtime.interceptors.ClassloadingIsolationInterceptor;
+import io.streamthoughts.azkarra.runtime.interceptors.KafkaBrokerReadyInterceptor;
 import io.streamthoughts.azkarra.runtime.interceptors.MonitoringStreamsInterceptor;
 import io.streamthoughts.azkarra.runtime.interceptors.WaitForSourceTopicsInterceptor;
 import io.streamthoughts.azkarra.runtime.streams.topology.InternalExecuted;
@@ -86,6 +87,7 @@ import static io.streamthoughts.azkarra.api.components.condition.Conditions.onPr
 import static io.streamthoughts.azkarra.runtime.components.ComponentDescriptorModifiers.withConditions;
 import static io.streamthoughts.azkarra.runtime.components.ComponentDescriptorModifiers.withOrder;
 import static io.streamthoughts.azkarra.runtime.interceptors.AutoCreateTopicsInterceptorConfig.AUTO_CREATE_TOPICS_ENABLE_CONFIG;
+import static io.streamthoughts.azkarra.runtime.interceptors.KafkaBrokerReadyInterceptorConfig.KAFKA_READY_INTERCEPTOR_ENABLE_CONFIG;
 import static io.streamthoughts.azkarra.runtime.interceptors.MonitoringStreamsInterceptorConfig.MONITORING_STREAMS_INTERCEPTOR_ENABLE_CONFIG;
 import static io.streamthoughts.azkarra.runtime.interceptors.WaitForSourceTopicsInterceptorConfig.WAIT_FOR_TOPICS_ENABLE_CONFIG;
 
@@ -176,6 +178,11 @@ public class DefaultAzkarraContext implements AzkarraContext {
         registerComponent(
             MonitoringStreamsInterceptor.class,
             withConditions(onPropertyTrue(MONITORING_STREAMS_INTERCEPTOR_ENABLE_CONFIG))
+        );
+        registerComponent(
+            KafkaBrokerReadyInterceptor.class,
+            withConditions(onPropertyTrue(KAFKA_READY_INTERCEPTOR_ENABLE_CONFIG)),
+            withOrder(Ordered.HIGHEST_ORDER)
         );
         registerComponent(
             WaitForSourceTopicsInterceptor.class,

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/AutoCreateTopicsInterceptor.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/AutoCreateTopicsInterceptor.java
@@ -151,7 +151,7 @@ public class AutoCreateTopicsInterceptor
         checkState();
         mayInitializeNewTopicsFromContext(context.topologyName());
 
-        if (context.streamsState() == State.CREATED) {
+        if (context.streamsState() == State.Standards.CREATED) {
 
             final Set<String> userDeclaredTopics = getUserDeclaredTopics(context.topologyDescription());
 
@@ -171,7 +171,7 @@ public class AutoCreateTopicsInterceptor
         chain.execute();
 
         // List all topics (i.e user-topics, change-log, repartition) only if streams application is running.
-        if (context.streamsState() == State.RUNNING) {
+        if (context.streamsState() == State.Standards.RUNNING) {
             apply(this::listTopics, context);
         }
     }

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/KafkaBrokerReadyInterceptor.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/KafkaBrokerReadyInterceptor.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.runtime.interceptors;
+
+import io.streamthoughts.azkarra.api.StreamsLifecycleChain;
+import io.streamthoughts.azkarra.api.StreamsLifecycleContext;
+import io.streamthoughts.azkarra.api.StreamsLifecycleInterceptor;
+import io.streamthoughts.azkarra.api.config.Conf;
+import io.streamthoughts.azkarra.api.config.Configurable;
+import io.streamthoughts.azkarra.api.streams.State;
+import io.streamthoughts.azkarra.api.streams.internal.InternalStreamsLifecycleContext;
+import io.streamthoughts.azkarra.api.time.Time;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeClusterOptions;
+import org.apache.kafka.common.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+
+public class KafkaBrokerReadyInterceptor implements StreamsLifecycleInterceptor, Configurable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaBrokerReadyInterceptor.class);
+
+    enum InterceptorState implements State {WAITING_FOR_KAFKA_BROKERS_READY}
+
+    private KafkaBrokerReadyInterceptorConfig config;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void configure(final Conf configs) {
+        config = new KafkaBrokerReadyInterceptorConfig(configs);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onStart(final StreamsLifecycleContext context, final StreamsLifecycleChain chain) {
+        if (config == null) throw new IllegalStateException("interceptor not configured");
+
+        final State previousState = context.streamsState();
+
+        boolean isReady = false;
+        int numBrokerAvailable = 0;
+        try {
+            LOG.info("Checking for Kafka to be ready. Expected broker(s): {}", config.getMinAvailableBrokers());
+            final var container = ((InternalStreamsLifecycleContext) context).container();
+            final var adminClient = container.getAdminClient();
+
+            final var start = Time.SYSTEM.milliseconds();
+            var remaining = config.getTimeoutMs();
+
+            while (remaining > 0) {
+                context.setState(InterceptorState.WAITING_FOR_KAFKA_BROKERS_READY);
+                try {
+                    Collection<Node> nodes = getClusterNodes(adminClient, remaining);
+                    numBrokerAvailable = nodes.size();
+                    if (isReady = !nodes.isEmpty() && numBrokerAvailable >= config.getMinAvailableBrokers()) {
+                        break;
+                    }
+                } catch (Exception e) {
+                    LOG.error("Unexpected error while listing Kafka nodes", e);
+                }
+                Time.SYSTEM.sleep(Duration.ofMillis(Math.min(config.getRetryBackoffMs(), remaining(start))));
+
+                LOG.info("Waiting for Kafka cluster to be ready. Expected {} brokers, but only {} was found.",
+                    config.getMinAvailableBrokers(),
+                    numBrokerAvailable
+                );
+                remaining = remaining(start);
+            }
+
+        } finally {
+            // always reset the previous state.
+            context.setState(previousState);
+            if (!isReady) {
+                LOG.warn(
+                    "Kafka Cluster is not ready yet. Expected {} brokers, but only {} was found. TimeoutMs expires",
+                    config.getMinAvailableBrokers(),
+                    numBrokerAvailable
+                );
+            }
+            chain.execute();
+        }
+    }
+
+    private long remaining(long start) {
+        return Math.max(0, config.getTimeoutMs() - (Time.SYSTEM.milliseconds() - start));
+    }
+
+    private Collection<Node> getClusterNodes(final AdminClient adminClient,
+                                             final long remaining) throws InterruptedException, ExecutionException {
+        return adminClient
+            .describeCluster(timeoutMsOptions(remaining))
+            .nodes()
+            .get();
+    }
+
+    private static DescribeClusterOptions timeoutMsOptions(final long remaining) {
+        return new DescribeClusterOptions().timeoutMs((int) Math.min(Integer.MAX_VALUE, remaining));
+    }
+}

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/KafkaBrokerReadyInterceptorConfig.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/KafkaBrokerReadyInterceptorConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.runtime.interceptors;
+
+import io.streamthoughts.azkarra.api.config.Conf;
+
+import java.util.Objects;
+
+public class KafkaBrokerReadyInterceptorConfig {
+
+    /** {@code kafka.ready.interceptor.enable} */
+    public static final String KAFKA_READY_INTERCEPTOR_ENABLE_CONFIG = "kafka.ready.interceptor.enable";
+
+    /** {@code kafka.ready.interceptor.timeout.ms} */
+    public static final String KAFKA_READY_INTERCEPTOR_TIMEOUT_MS_CONFIG = "kafka.ready.interceptor.timeout.ms";
+    public static final long KAFKA_READY_INTERCEPTOR_TIMEOUT_MS_DEFAULT = 60_000L;
+
+    /** {@code kafka.ready.interceptor.connect.backoff.ms} */
+    public static final String KAFKA_READY_INTERCEPTOR_RETRY_BACKOFF_MS_CONFIG = "kafka.ready.interceptor.retry.backoff.ms";
+    public static final long KAFKA_READY_INTERCEPTOR_RETRY_BACKOFF_MS_DEFAULT = 1_000;
+
+    /** {@code kafka.ready.interceptor.min.available.brokers} */
+    public static final String KAFKA_READY_INTERCEPTOR_MIN_AVAILABLE_BROKERS_CONFIG = "kafka.ready.interceptor.min.available.brokers";
+    public static final int KAFKA_READY_INTERCEPTOR_MIN_AVAILABLE_BROKERS_DEFAULT = 1;
+
+    private final Conf originals;
+
+    /**
+     * Creates a new {@link KafkaBrokerReadyInterceptorConfig} instance.
+     *
+     * @param originals the {@link Conf}.
+     */
+    public KafkaBrokerReadyInterceptorConfig(final Conf originals) {
+        this.originals = Objects.requireNonNull(originals);
+    }
+
+    public long getTimeoutMs() {
+        return originals
+            .getOptionalLong(KAFKA_READY_INTERCEPTOR_TIMEOUT_MS_CONFIG)
+            .orElse(KAFKA_READY_INTERCEPTOR_TIMEOUT_MS_DEFAULT);
+    }
+
+    public long getRetryBackoffMs() {
+        return originals
+            .getOptionalLong(KAFKA_READY_INTERCEPTOR_RETRY_BACKOFF_MS_CONFIG)
+            .orElse(KAFKA_READY_INTERCEPTOR_RETRY_BACKOFF_MS_DEFAULT);
+    }
+
+    public int getMinAvailableBrokers() {
+        return originals
+            .getOptionalInt(KAFKA_READY_INTERCEPTOR_MIN_AVAILABLE_BROKERS_CONFIG)
+            .orElse(KAFKA_READY_INTERCEPTOR_MIN_AVAILABLE_BROKERS_DEFAULT);
+    }
+}

--- a/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/WaitForSourceTopicsInterceptor.java
+++ b/azkarra-runtime/src/main/java/io/streamthoughts/azkarra/runtime/interceptors/WaitForSourceTopicsInterceptor.java
@@ -47,6 +47,8 @@ public class WaitForSourceTopicsInterceptor implements StreamsLifecycleIntercept
 
     private final AdminClient adminClient;
 
+    enum InterceptorState implements State { WAITING_FOR_TOPICS }
+
     /**
      * Creates a new {@link WaitForSourceTopicsInterceptor} instance.
      */
@@ -68,14 +70,14 @@ public class WaitForSourceTopicsInterceptor implements StreamsLifecycleIntercept
      */
     @Override
     public void onStart(final StreamsLifecycleContext context, final StreamsLifecycleChain chain) {
-        if (context.streamsState() == State.CREATED) {
+        if (context.streamsState() == State.Standards.CREATED) {
             final Set<String> sourceTopics = getSourceTopics(context.topologyDescription())
                 .stream()
                 .filter(Predicate.not(TopologyUtils::isInternalTopic))
                 .collect(Collectors.toSet());
 
             if (!sourceTopics.isEmpty()) {
-                context.setState(State.WAITING_FOR_TOPICS);
+                context.setState(InterceptorState.WAITING_FOR_TOPICS);
                 apply(context, client -> {
                     LOG.info("Waiting for source topic(s) to be created: {}", sourceTopics);
                     try {

--- a/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/interceptors/AutoCreateTopicsInterceptorTest.java
+++ b/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/interceptors/AutoCreateTopicsInterceptorTest.java
@@ -160,7 +160,7 @@ public class AutoCreateTopicsInterceptorTest {
 
     private StreamsLifecycleContext newContext() {
         return new StreamsLifecycleContext() {
-            State state = State.CREATED;
+            State state = State.Standards.CREATED;
 
             @Override
             public String applicationId() {

--- a/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/interceptors/KafkaBrokerReadyInterceptorConfigTest.java
+++ b/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/interceptors/KafkaBrokerReadyInterceptorConfigTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.runtime.interceptors;
+
+import io.streamthoughts.azkarra.api.config.Conf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static io.streamthoughts.azkarra.runtime.interceptors.KafkaBrokerReadyInterceptorConfig.*;
+
+public class KafkaBrokerReadyInterceptorConfigTest {
+
+    @Test
+    public void shouldReturnDefaultValueGivenEmptyConfig() {
+        var config = new KafkaBrokerReadyInterceptorConfig(Conf.empty());
+        Assertions.assertEquals(KAFKA_READY_INTERCEPTOR_MIN_AVAILABLE_BROKERS_DEFAULT, config.getMinAvailableBrokers());
+        Assertions.assertEquals(KAFKA_READY_INTERCEPTOR_RETRY_BACKOFF_MS_DEFAULT, config.getRetryBackoffMs());
+        Assertions.assertEquals(KAFKA_READY_INTERCEPTOR_TIMEOUT_MS_DEFAULT, config.getTimeoutMs());
+    }
+
+    @Test
+    public void shouldReturnConfiguredValueGivenNonEmptyConfig() {
+        var config = new KafkaBrokerReadyInterceptorConfig(Conf.of(
+                KAFKA_READY_INTERCEPTOR_MIN_AVAILABLE_BROKERS_CONFIG, "3",
+                KAFKA_READY_INTERCEPTOR_RETRY_BACKOFF_MS_CONFIG, 100,
+                KAFKA_READY_INTERCEPTOR_TIMEOUT_MS_CONFIG, 10
+        ));
+        Assertions.assertEquals(3, config.getMinAvailableBrokers());
+        Assertions.assertEquals(100, config.getRetryBackoffMs());
+        Assertions.assertEquals(10, config.getTimeoutMs());
+    }
+}

--- a/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/interceptors/KafkaBrokerReadyInterceptorTest.java
+++ b/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/interceptors/KafkaBrokerReadyInterceptorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 StreamThoughts.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamthoughts.azkarra.runtime.interceptors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class KafkaBrokerReadyInterceptorTest {
+
+    @Test
+    public void shouldThrowIllegalStateExceptionWhenInterceptorIsNotConfigured() {
+        Assertions.assertThrows(IllegalStateException.class,
+            () -> new KafkaBrokerReadyInterceptor().onStart(null, null)
+        );
+    }
+}

--- a/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/streams/topology/TopologyUtilsTest.java
+++ b/azkarra-runtime/src/test/java/io/streamthoughts/azkarra/runtime/streams/topology/TopologyUtilsTest.java
@@ -105,6 +105,8 @@ public class TopologyUtilsTest {
                 .to("output-topic");
         topology = builder.build();
 
+        System.out.println(topology.describe());
+
         final Set<String> sourceTopics = getSourceTopics(topology.describe())
                 .stream()
                 .filter(Predicate.not(TopologyUtils::isInternalTopic))

--- a/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/health/internal/StreamsHealthIndicator.java
+++ b/azkarra-server/src/main/java/io/streamthoughts/azkarra/http/health/internal/StreamsHealthIndicator.java
@@ -78,20 +78,19 @@ public class StreamsHealthIndicator implements HealthIndicator, AzkarraContextAw
                                  final Health.Builder builder) {
         final State value = container.state().value();
         final Optional<Throwable> exception = container.exception();
-        switch (value) {
-            case RUNNING :
-                builder.up();
-                break;
-            case ERROR :
-                builder.down();
-                exception.ifPresent(builder::withException);
-                break;
-            case NOT_RUNNING:
-                exception.ifPresentOrElse(e -> builder.down().withException(e), builder::unknown);
-                break;
-            default:
-                builder.unknown();
-                break;
+
+        if (value.equals(State.Standards.RUNNING)) {
+            builder.up();
+
+        } else if (value.equals(State.Standards.ERROR)) {
+            builder.down();
+            exception.ifPresent(builder::withException);
+        }
+        else if (value.equals(State.Standards.NOT_RUNNING)) {
+            exception.ifPresentOrElse(e -> builder.down().withException(e), builder::unknown);
+
+        } else {
+            builder.unknown();
         }
     }
 

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -33,6 +33,7 @@
     <suppress checks="LineLength" files="io.streamthoughts.azkarra.runtime.interceptors.MonitoringStreamsInterceptorConfig" />
     <suppress checks="LineLength" files="io.streamthoughts.azkarra.streams.components.ComponentResolver"/>
     <suppress checks="LineLength" files="io.streamthoughts.azkarra.api.streams.consumer.LogOffsetsFetcher" />
+    <suppress checks="LineLength" files="io.streamthoughts.azkarra.runtime.interceptors.KafkaBrokerReadyInterceptorConfig" />
     <suppress checks="NPathComplexity" files="io.streamthoughts.azkarra.commons.error.SafeDeserializerConfig"/>
     <suppress checks="ClassFanOutComplexity" files="io.streamthoughts.azkarra.api.streams.KafkaStreamsContainer"/>
     <suppress checks="ParameterNumber" files="SimpleComponentDescriptor" />


### PR DESCRIPTION
This commit adds a new built-in interceptor named
KafkaBrokerReadyInterceptor which can be enable by setting the property
kafka.ready.interceptor.enable to true

Breaking changes:
 - The State enum is changed to be an interface to support custom State implementation.

Resolves: GH-51